### PR TITLE
Virustotal integration for IP scans

### DIFF
--- a/integrations/virustotal-ip/README.md
+++ b/integrations/virustotal-ip/README.md
@@ -1,0 +1,384 @@
+# Wazuh - VirusTotal IP Reputation Integration
+
+## Table of Contents
+
+- [Introduction](#introduction)
+- [Heuristic (How the Verdict is Decided)](#heuristic-how-the-verdict-is-decided)
+   - [Default Thresholds](#default-thresholds-from-custom-virustotal_ip_checkspy)
+- [Installation and Configuration](#installation-and-configuration)
+- [Wazuh Configuration](#wazuh-configuration)
+   - [Integrator Config (manager `ossec.conf`)](#integrator-config-manager-ossecconf)
+   - [Custom Rules](#custom-rules)
+   - [Manual Tests](#manual-tests)
+     - [Test 1: Malicious IP](#test-1-malicious-ip)
+     - [Test 2: Valid IP](#test-2-valid-ip)
+- [Workflow Diagram](#workflow-diagram)
+
+## Introduction
+
+This integration enriches Wazuh alerts with **VirusTotal IP reputation** and returns a clear verdict: **malicious**, **suspicious**, or **unknown**. It’s built on Wazuh’s Integrator framework and the VirusTotal **v3** API.
+
+This integration can be broken down into the following steps:
+
+* Extracts the **source IP** from matching Wazuh alerts.
+* Queries VirusTotal’s **IP object** (`/api/v3/ip_addresses/{ip}`) and (optionally) pivots to **communicating files** for borderline cases.
+* Computes a verdict using **engine consensus, freshness, community reputation, risk tags**, and **light engine-weighting**.
+* Emits an enriched JSON block under `virustotal_ip` and a flat `verdict_line` string for easy rule matching.
+
+## Heuristic (How the Verdict is Decided)
+
+It seems that there are multiple sources and sometimes the IP might not get directly flagged as malicious. To add more functionality and security, I have come up with a heuristic that will flag the IP based on multiple factors:
+
+* **M** = `last_analysis_stats.malicious`
+* **S** = `last_analysis_stats.suspicious`
+* **REP** = `reputation` (community score: neg=bad, pos=good)
+* **AGE\_DAYS** = `now - last_analysis_date` (in days)
+* **TAGS** = `attributes.tags` (vpn, tor, proxy)
+
+Here is the decision flow:
+
+1. **Start with engine counts**
+
+      * If `malicious` ≥ 3 → **malicious**.
+      * Else if `malicious` ≥ 1 and `reputation` < 0 → **malicious**.
+      * Else if (`malicious` + `suspicious`) ≥ 1 → **suspicious** (unless weak due to date).
+      * Else → **unknown**.
+
+2. **Apply date (only affects weak hits as IPs can get refreshed):**
+
+      * If `age_days` > 90, `malicious` ≤ 1, and `reputation` ≥ 0 → downgrade to **unknown**.
+
+3. **Apply lightweight engine weighting**
+
+      * If score ≥ 3.0 → **malicious** (consensus by score).
+      * Else if score ≥ 1.5 and verdict was **unknown** → **suspicious**.
+
+4. **Apply risk tags guardrail**
+
+      * If there’s any hit (`malicious` or `suspicious` > 0) and tag in `RISK_TAGS`, make sure it’s at least **suspicious**.
+
+For a better visual, please refer to [Workflow Diagram](#workflow-diagram)
+
+### Default Thresholds (from `custom-virustotal_ip.py`)
+
+Note that the values of the constants are at the top of the script. You can adjust them however you like.
+
+```python
+# Primary threshold: how many "malicious" engines to call it malicious outright
+MAL_STRONG_MIN: int = 3
+
+# If at least this many malicious (>=1) AND reputation < REP_BAD_LT -> malicious
+REP_BAD_LT: int = 0  # negative reputation considered bad
+
+# Lightweight engine weighting from last_analysis_results
+# malicious = 1.0 point, suspicious = 0.5 point
+WEIGHT_MAL_STRONG: float = 3.0   # upgrade to malicious if weighted >= this
+WEIGHT_MAL_SUS: float    = 1.5   # upgrade unknown -> suspicious if weighted >= this
+
+# If analysis is older than this (days) and hits are weak (<=1 malicious) with non-negative rep -> unknown
+STALE_WEAK_DAYS: int = 90
+
+# Risk tags that prevent downgrading below suspicious if there is any engine hit
+RISK_TAGS = {"tor", "vpn", "proxy", "anonymizer", "anonymous"}
+```
+
+## Installation and Configuration
+
+This integration uses two files: a shell script wrapper called by Wazuh and the Python script that performs the logic.
+
+* Python Script: `/var/ossec/integrations/custom-virustotal_ip.py`
+* Shell Wrapper: `/var/ossec/integrations/custom-virustotal_ip`
+
+**Place & permissions:**
+Place the [This python script](custom-virustotal_ip.py) and the [shell wrapper](custom-virustotal_ip) in /var/ossec/integrations/ and adjust permissions.
+
+```bash
+
+chmod 750 /var/ossec/integrations/custom-virustotal_ip*
+chown root:wazuh /var/ossec/integrations/custom-virustotal_ip*
+```
+
+## Wazuh Configuration
+
+### Integrator Config (manager `ossec.conf`)
+
+Add the following block to `/var/ossec/etc/ossec.conf`. The `<name>` must match the shell script wrapper.
+
+```xml
+<integration>
+  <name>custom-virustotal_ip</name>
+  <api_key>YOUR_VT_KEY</api_key> <!-- replace this with your API key -->
+  <group>sshd</group> <!-- you can use groups,rule_id or event_location-->
+  <alert_format>json</alert_format>
+</integration>
+```
+
+### Custom Rules
+
+Add [the custom rules](./custom_virustotal.xml) to trigger alerts whenever the scans come back:
+
+### Manual Tests
+
+#### Test 1: Malicious IP
+
+```bash
+[root@wazuh-server ~]# python3 /var/ossec/integrations/custom-virustotal_ip.py /var/log/abuseipdb.json $VT_API_KEY sshd debug
+# Running VirusTotal IP script
+# Opening alert file at '/var/log/abuseipdb.json' with '{'timestamp': '2025-07-21T12:41:18.157+0000', 'rule': {'level': 5, 'description': 'sshd: Authentication succeeded from a public IP address 64.62.197.132.', 'id': '100003', 'firedtimes': 2, 'mail': False, 'groups': ['local', 'syslog', 'sshd', 'authentication_failed', 'authentication_success'], 'pci_dss': ['10.2.4', '10.2.5']}, 'agent': {'id': '000', 'name': 'rhel9.localdomain'}, 'manager': {'name': 'rhel9.localdomain'}, 'id': '1753101678.8211', 'full_log': 'Dec 10 01:02:02 host sshd[1234]: Accepted none for root from 64.62.197.132 port 1066 ssh2', 'predecoder': {'program_name': 'sshd', 'timestamp': 'Dec 10 01:02:02', 'hostname': 'host'}, 'decoder': {'parent': 'sshd', 'name': 'sshd'}, 'data': {'srcip': '64.62.197.132', 'srcport': '1066', 'dstuser': 'root'}, 'location': '/var/log/test.log'}'
+# Request result from VT server: 1:virustotal_ip:{"virustotal_ip": {"found": 1, "verdict": "malicious", "source": {"alert_id": "1753101678.8211", "rule": "100003", "ip": "64.62.197.132"}, "counts": {"malicious": 11, "suspicious": 2}, "engine_counts": {"malicious": 11, "suspicious": 2}, "weighted_malicious": 12.0, "reputation": -3, "tags": [], "age_days": 0.7, "last_analysis_date": "2025-12-04T16:45:36+00:00", "country": "US", "as_owner": "HURRICANE", "network": "64.62.197.0/24", "permalink": "https://www.virustotal.com/gui/ip-address/64.62.197.132", "pivot": {"used": false}, "verdict_line": "vt_ip verdict=malicious ip=64.62.197.132 mal=11 sus=2 wmal=12.0 rep=-3 age_days=0.7 tags=- as_owner=\"HURRICANE\""}, "integration": "virustotal_ip", "original_full_log": "Dec 10 01:02:02 host sshd[1234]: Accepted none for root from 64.62.197.132 port 1066 ssh2"}
+
+```
+
+**JSON event from archives (Malicious):**
+
+```json
+{
+  "_index": "wazuh-alerts-4.x-2025.12.05",
+  "_id": "Vkv_7ZoBMYYtzkfpm7zp",
+  "_version": 1,
+  "_score": null,
+  "_source": {
+    "input": {
+      "type": "log"
+    },
+    "agent": {
+      "name": "wazuh-server",
+      "id": "000"
+    },
+    "manager": {
+      "name": "wazuh-server"
+    },
+    "data": {
+      "virustotal_ip": {
+        "age_days": "0.700000",
+        "country": "US",
+        "counts": {
+          "malicious": "11",
+          "suspicious": "2"
+        },
+        "as_owner": "HURRICANE",
+        "reputation": "-3",
+        "verdict_line": "vt_ip verdict=malicious ip=64.62.197.132 mal=11 sus=2 wmal=12.0 rep=-3 age_days=0.7 tags=- as_owner=\"HURRICANE\"",
+        "source": {
+          "alert_id": "1753101678.8211",
+          "ip": "64.62.197.132",
+          "rule": "100003"
+        },
+        "tags": [],
+        "network": "64.62.197.0/24",
+        "found": "1",
+        "weighted_malicious": "12",
+        "last_analysis_date": "2025-12-04T16:45:36+00:00",
+        "verdict": "malicious",
+        "pivot": {
+          "used": "false"
+        },
+        "engine_counts": {
+          "malicious": "11",
+          "suspicious": "2"
+        },
+        "permalink": "https://www.virustotal.com/gui/ip-address/64.62.197.132"
+      },
+      "integration": "virustotal_ip",
+      "original_full_log": "Dec 10 01:02:02 host sshd[1234]: Accepted none for root from 64.62.197.132 port 1066 ssh2"
+    },
+    "rule": {
+      "firedtimes": 1,
+      "mail": true,
+      "level": 12,
+      "description": "Source IP flagged malicious by VirusTotal",
+      "groups": [
+        "local",
+        "virustotal",
+        "vt_ip"
+      ],
+      "id": "199901"
+    },
+    "event_fingerprint": "ebdf2fcf472fcd45ff1e0b9ac9a526d39da4bb20ec574a467536b86b399e3092",
+    "location": "virustotal_ip",
+    "decoder": {
+      "name": "json"
+    },
+    "id": "1764929536.7192965",
+    "full_log": "{\"virustotal_ip\": {\"found\": 1, \"verdict\": \"malicious\", \"source\": {\"alert_id\": \"1753101678.8211\", \"rule\": \"100003\", \"ip\": \"64.62.197.132\"}, \"counts\": {\"malicious\": 11, \"suspicious\": 2}, \"engine_counts\": {\"malicious\": 11, \"suspicious\": 2}, \"weighted_malicious\": 12.0, \"reputation\": -3, \"tags\": [], \"age_days\": 0.7, \"last_analysis_date\": \"2025-12-04T16:45:36+00:00\", \"country\": \"US\", \"as_owner\": \"HURRICANE\", \"network\": \"64.62.197.0/24\", \"permalink\": \"https://www.virustotal.com/gui/ip-address/64.62.197.132\", \"pivot\": {\"used\": false}, \"verdict_line\": \"vt_ip verdict=malicious ip=64.62.197.132 mal=11 sus=2 wmal=12.0 rep=-3 age_days=0.7 tags=- as_owner=\\\"HURRICANE\\\"\"}, \"integration\": \"virustotal_ip\", \"original_full_log\": \"Dec 10 01:02:02 host sshd[1234]: Accepted none for root from 64.62.197.132 port 1066 ssh2\"}",
+    "timestamp": "2025-12-05T11:12:16.827+0100"
+  },
+  "fields": {
+    "timestamp": [
+      "2025-12-05T10:12:16.827Z"
+    ]
+  },
+  "highlight": {
+    "rule.groups": [
+      "@opensearch-dashboards-highlighted-field@virustotal@/opensearch-dashboards-highlighted-field@"
+    ]
+  },
+  "sort": [
+    1764929536827
+  ]
+}
+```
+
+#### Test 2: Valid IP
+
+```bash
+[root@wazuh-server integrations]# nslookup wazuh.com
+Server:		10.0.2.3
+Address:	10.0.2.3#53
+Non-authoritative answer:
+Name:	wazuh.com
+Address: 108.157.98.17
+Name:	wazuh.com
+Address: 108.157.98.61
+Name:	wazuh.com
+Address: 108.157.98.96
+Name:	wazuh.com
+Address: 108.157.98.48
+[root@wazuh-server ~]# nano /var/log/abuseipdb.json
+[root@wazuh-server ~]# python3 /var/ossec/integrations/custom-virustotal_ip.py /var/log/abuseipdb.json $VT_API_KEY sshd debug
+# Running VirusTotal IP script
+# Opening alert file at '/var/log/abuseipdb.json' with '{'timestamp': '2025-07-21T12:41:18.157+0000', 'rule': {'level': 5, 'description': 'sshd: Authentication succeeded from a public IP address 108.157.98.17.', 'id': '100003', 'firedtimes': 2, 'mail': False, 'groups': ['local', 'syslog', 'sshd', 'authentication_failed', 'authentication_success'], 'pci_dss': ['10.2.4', '10.2.5']}, 'agent': {'id': '000', 'name': 'rhel9.localdomain'}, 'manager': {'name': 'rhel9.localdomain'}, 'id': '1753101678.8211', 'full_log': 'Dec 10 01:02:02 host sshd[1234]: Accepted none for root from 108.157.98.17 port 1066 ssh2', 'predecoder': {'program_name': 'sshd', 'timestamp': 'Dec 10 01:02:02', 'hostname': 'host'}, 'decoder': {'parent': 'sshd', 'name': 'sshd'}, 'data': {'srcip': '108.157.98.17', 'srcport': '1066', 'dstuser': 'root'}, 'location': '/var/log/test.log'}'
+# Request result from VT server: 1:virustotal_ip:{"virustotal_ip": {"found": 1, "verdict": "unknown", "source": {"alert_id": "1753101678.8211", "rule": "100003", "ip": "108.157.98.17"}, "counts": {"malicious": 0, "suspicious": 0}, "engine_counts": {"malicious": 0, "suspicious": 0}, "weighted_malicious": 0.0, "reputation": 0, "tags": [], "age_days": 138.7, "last_analysis_date": "2025-07-19T18:14:19+00:00", "country": "US", "as_owner": "AMAZON-02", "network": "108.157.96.0/22", "permalink": "https://www.virustotal.com/gui/ip-address/108.157.98.17", "pivot": {"used": true, "total_files": 1, "strong_mal_files": 0}, "verdict_line": "vt_ip verdict=unknown ip=108.157.98.17 mal=0 sus=0 wmal=0.0 rep=0 age_days=138.7 tags=- as_owner=\"AMAZON-02\""}, "integration": "virustotal_ip", "original_full_log": "Dec 10 01:02:02 host sshd[1234]: Accepted none for root from 108.157.98.17 port 1066 ssh2"}
+
+```
+
+**JSON event from archives (Unknown):**
+
+```json
+{
+  "_index": "wazuh-alerts-4.x-low22-2025.12.05",
+  "_id": "nEsF7poBMYYtzkfpScCd",
+  "_version": 1,
+  "_score": null,
+  "_source": {
+    "input": {
+      "type": "log"
+    },
+    "agent": {
+      "name": "wazuh-server",
+      "id": "000"
+    },
+    "manager": {
+      "name": "wazuh-server"
+    },
+    "data": {
+      "virustotal_ip": {
+        "age_days": "138.700000",
+        "country": "US",
+        "counts": {
+          "malicious": "0",
+          "suspicious": "0"
+        },
+        "as_owner": "AMAZON-02",
+        "reputation": "0",
+        "verdict_line": "vt_ip verdict=unknown ip=108.157.98.17 mal=0 sus=0 wmal=0.0 rep=0 age_days=138.7 tags=- as_owner=\"AMAZON-02\"",
+        "source": {
+          "alert_id": "1753101678.8211",
+          "ip": "108.157.98.17",
+          "rule": "100003"
+        },
+        "tags": [],
+        "network": "108.157.96.0/22",
+        "found": "1",
+        "weighted_malicious": "0",
+        "last_analysis_date": "2025-07-19T18:14:19+00:00",
+        "verdict": "unknown",
+        "pivot": {
+          "total_files": "1",
+          "strong_mal_files": "0",
+          "used": "true"
+        },
+        "engine_counts": {
+          "malicious": "0",
+          "suspicious": "0"
+        },
+        "permalink": "https://www.virustotal.com/gui/ip-address/108.157.98.17"
+      },
+      "integration": "virustotal_ip",
+      "original_full_log": "Dec 10 01:02:02 host sshd[1234]: Accepted none for root from 108.157.98.17 port 1066 ssh2"
+    },
+    "rule": {
+      "firedtimes": 1,
+      "mail": false,
+      "level": 3,
+      "description": "Source IP unknown per VirusTotal",
+      "groups": [
+        "local",
+        "virustotal",
+        "vt_ip"
+      ],
+      "id": "199903"
+    },
+    "event_fingerprint": "d258b4bb2a9e554128a0e1485bb5ad8af9938bda2e184b6726319a258f561187",
+    "location": "virustotal_ip",
+    "decoder": {
+      "name": "json"
+    },
+    "id": "1764929911.7366664",
+    "full_log": "{\"virustotal_ip\": {\"found\": 1, \"verdict\": \"unknown\", \"source\": {\"alert_id\": \"1753101678.8211\", \"rule\": \"100003\", \"ip\": \"108.157.98.17\"}, \"counts\": {\"malicious\": 0, \"suspicious\": 0}, \"engine_counts\": {\"malicious\": 0, \"suspicious\": 0}, \"weighted_malicious\": 0.0, \"reputation\": 0, \"tags\": [], \"age_days\": 138.7, \"last_analysis_date\": \"2025-07-19T18:14:19+00:00\", \"country\": \"US\", \"as_owner\": \"AMAZON-02\", \"network\": \"108.157.96.0/22\", \"permalink\": \"https://www.virustotal.com/gui/ip-address/108.157.98.17\", \"pivot\": {\"used\": true, \"total_files\": 1, \"strong_mal_files\": 0}, \"verdict_line\": \"vt_ip verdict=unknown ip=108.157.98.17 mal=0 sus=0 wmal=0.0 rep=0 age_days=138.7 tags=- as_owner=\\\"AMAZON-02\\\"\"}, \"integration\": \"virustotal_ip\", \"original_full_log\": \"Dec 10 01:02:02 host sshd[1234]: Accepted none for root from 108.157.98.17 port 1066 ssh2\"}",
+    "timestamp": "2025-12-05T11:18:31.597+0100"
+  },
+  "fields": {
+    "timestamp": [
+      "2025-12-05T10:18:31.597Z"
+    ]
+  },
+  "highlight": {
+    "rule.groups": [
+      "@opensearch-dashboards-highlighted-field@virustotal@/opensearch-dashboards-highlighted-field@"
+    ]
+  },
+  "sort": [
+    1764929911597
+  ]
+}
+```
+
+## Workflow Diagram
+
+```mermaid
+flowchart TD
+    Start([Start: Analyze IP]) --> CheckMal3{Malicious ≥ 3?}
+    
+    CheckMal3 -->|Yes| Malicious1[Verdict: MALICIOUS]
+    CheckMal3 -->|No| CheckMal1Rep{Malicious ≥ 1<br/>AND<br/>Reputation < 0?}
+    
+    CheckMal1Rep -->|Yes| Malicious2[Verdict: MALICIOUS]
+    CheckMal1Rep -->|No| CheckMalSus{Malicious +<br/>Suspicious ≥ 1?}
+    
+    CheckMalSus -->|Yes| Suspicious1[Verdict: SUSPICIOUS]
+    CheckMalSus -->|No| Unknown1[Verdict: UNKNOWN]
+    
+    Suspicious1 --> DateCheck{Age > 90 days<br/>AND<br/>Malicious ≤ 1<br/>AND<br/>Reputation ≥ 0?}
+    Unknown1 --> WeightCheck
+    
+    DateCheck -->|Yes| Downgrade[Downgrade to UNKNOWN]
+    DateCheck -->|No| WeightCheck{Weighted Score?}
+    
+    Downgrade --> WeightCheck
+    Malicious1 --> WeightCheck
+    Malicious2 --> WeightCheck
+    
+    WeightCheck -->|Score ≥ 3.0| UpgradeMal[Upgrade to MALICIOUS]
+    WeightCheck -->|Score ≥ 1.5<br/>AND<br/>Current = UNKNOWN| UpgradeSus[Upgrade to SUSPICIOUS]
+    WeightCheck -->|Neither| RiskTagCheck
+    
+    UpgradeMal --> RiskTagCheck{Any hits AND<br/>Risk Tag present?}
+    UpgradeSus --> RiskTagCheck
+    
+    RiskTagCheck -->|Yes| EnsureSus[Ensure at least<br/>SUSPICIOUS]
+    RiskTagCheck -->|No| FinalVerdict[Final Verdict]
+    
+    EnsureSus --> FinalVerdict
+    FinalVerdict --> End([End])
+    
+    style Malicious1 fill:#ff6b6b
+    style Malicious2 fill:#ff6b6b
+    style UpgradeMal fill:#ff6b6b
+    style Suspicious1 fill:#ffa500
+    style UpgradeSus fill:#ffa500
+    style EnsureSus fill:#ffa500
+    style Unknown1 fill:#gray
+    style Downgrade fill:#gray
+    style FinalVerdict fill:#4ecdc4
+```

--- a/integrations/virustotal-ip/custom-virustotal_ip
+++ b/integrations/virustotal-ip/custom-virustotal_ip
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Copyright (C) 2015, Wazuh Inc.
+# Created by Wazuh, Inc. <info@wazuh.com>.
+# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
+
+WPYTHON_BIN="framework/python/bin/python3"
+
+SCRIPT_PATH_NAME="$0"
+
+DIR_NAME="$(cd $(dirname ${SCRIPT_PATH_NAME}); pwd -P)"
+SCRIPT_NAME="$(basename ${SCRIPT_PATH_NAME})"
+
+case ${DIR_NAME} in
+    */active-response/bin | */wodles*)
+        if [ -z "${WAZUH_PATH}" ]; then
+            WAZUH_PATH="$(cd ${DIR_NAME}/../..; pwd)"
+        fi
+
+        PYTHON_SCRIPT="${DIR_NAME}/${SCRIPT_NAME}.py"
+    ;;
+    */bin)
+        if [ -z "${WAZUH_PATH}" ]; then
+            WAZUH_PATH="$(cd ${DIR_NAME}/..; pwd)"
+        fi
+
+        PYTHON_SCRIPT="${WAZUH_PATH}/framework/scripts/$(echo ${SCRIPT_NAME} | sed 's/\-/_/g').py"
+    ;;
+     */integrations)
+        if [ -z "${WAZUH_PATH}" ]; then
+            WAZUH_PATH="$(cd ${DIR_NAME}/..; pwd)"
+        fi
+
+        PYTHON_SCRIPT="${DIR_NAME}/${SCRIPT_NAME}.py"
+    ;;
+esac
+
+
+${WAZUH_PATH}/${WPYTHON_BIN} ${PYTHON_SCRIPT} "$@"

--- a/integrations/virustotal-ip/custom-virustotal_ip.py
+++ b/integrations/virustotal-ip/custom-virustotal_ip.py
@@ -1,0 +1,365 @@
+#!/var/ossec/framework/python/bin/python3
+# Copyright (C) 2015-2025, Wazuh Inc.
+#
+# Example ossec.conf:
+# <integration>
+#   <name>custom-virustotal_ip</name>
+#   <api_key>YOUR_VT_KEY</api_key>
+#   <group>sshd</group>   #   <alert_format>json</alert_format>
+# </integration>
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from socket import AF_UNIX, SOCK_DGRAM, socket
+
+# ===================== Heuristic constants (tune here) =====================
+
+# Primary threshold: how many "malicious" engines to call it malicious outright
+MAL_STRONG_MIN: int = 3
+
+# If at least this many malicious (>=1) AND reputation < REP_BAD_LT -> malicious
+REP_BAD_LT: int = 0  # negative reputation considered bad
+
+# Lightweight engine weighting from last_analysis_results
+# malicious = 1.0 point, suspicious = 0.5 point
+WEIGHT_MAL_STRONG: float = 3.0   # upgrade to malicious if weighted >= this
+WEIGHT_MAL_SUS: float    = 1.5   # upgrade unknown -> suspicious if weighted >= this
+
+# If analysis is older than this (days) and hits are weak (<=1 malicious) with non-negative rep -> unknown
+STALE_WEAK_DAYS: int = 90
+
+# Risk tags that prevent downgrading below suspicious if there is any engine hit
+RISK_TAGS = {"tor", "vpn", "proxy", "anonymizer", "anonymous"}
+
+# ============================ Exit error codes =============================
+
+ERR_NO_REQUEST_MODULE = 1
+ERR_BAD_ARGUMENTS = 2
+ERR_NO_RESPONSE_VT = 4
+ERR_SOCKET_OPERATION = 5
+ERR_FILE_NOT_FOUND = 6
+ERR_INVALID_JSON = 7
+ERR_NO_IP_FOUND = 8
+
+try:
+    import requests
+    from requests.exceptions import Timeout, RequestException
+except Exception:
+    print("No module 'requests' found. Install: pip install requests")
+    sys.exit(ERR_NO_REQUEST_MODULE)
+
+# ============================ Globals / paths ==============================
+
+debug_enabled = False
+timeout = 10
+retries = 3
+pwd = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+LOG_FILE = f"{pwd}/logs/integrations.log"
+SOCKET_ADDR = f"{pwd}/queue/sockets/queue"
+
+# Argument positions per Wazuh Integrator call
+ALERT_INDEX = 1
+APIKEY_INDEX = 2
+TIMEOUT_INDEX = 6
+RETRIES_INDEX = 7
+
+VT_IP_URL = "https://www.virustotal.com/api/v3/ip_addresses/{ip}"
+
+# ================================ Main ====================================
+
+def main(args):
+    global debug_enabled, timeout, retries
+    try:
+        bad_arguments = False
+        msg = ""
+        if len(args) >= 4:
+            debug_enabled = len(args) > 4 and args[4] == "debug"
+            if len(args) > TIMEOUT_INDEX:
+                timeout = int(args[TIMEOUT_INDEX])
+            if len(args) > RETRIES_INDEX:
+                retries = int(args[RETRIES_INDEX])
+        else:
+            msg = "# Error: Wrong arguments\n"
+            bad_arguments = True
+
+        with open(LOG_FILE, "a") as f:
+            f.write(msg)
+
+        if bad_arguments:
+            debug(f"# Error: Exiting, bad arguments. Inputted: {args}")
+            sys.exit(ERR_BAD_ARGUMENTS)
+
+        process_args(args)
+
+    except Exception as e:
+        debug(str(e))
+        raise
+
+
+def process_args(args):
+    debug("# Running VirusTotal IP script")
+
+    alert_file_location = args[ALERT_INDEX]
+    apikey_raw = args[APIKEY_INDEX]
+    apikey = parse_api_key(apikey_raw)
+
+    json_alert = get_json_alert(alert_file_location)
+    debug(f"# Opening alert file at '{alert_file_location}' with '{json_alert}'")
+
+    msg = request_virustotal_info(json_alert, apikey)
+    if not msg:
+        debug("# Error: Empty message")
+        raise Exception
+
+    send_msg(msg, json_alert.get("agent"))
+
+# ================================ Utils ===================================
+
+def debug(msg: str):
+    if debug_enabled:
+        print(msg)
+        with open(LOG_FILE, "a") as f:
+            f.write(msg + "\n")
+
+
+def parse_api_key(arg):
+    # Wazuh may pass "api_key:VALUE" or just "VALUE"
+    if isinstance(arg, str) and ":" in arg:
+        _, v = arg.split(":", 1)
+        return v
+    return arg
+
+
+def get_json_alert(file_location: str):
+    try:
+        with open(file_location) as alert_file:
+            return json.load(alert_file)
+    except FileNotFoundError:
+        debug(f"# JSON file for alert {file_location} doesn't exist")
+        sys.exit(ERR_FILE_NOT_FOUND)
+    except json.decoder.JSONDecodeError as e:
+        debug(f"Failed getting JSON alert. Error: {e}")
+        sys.exit(ERR_INVALID_JSON)
+
+
+# Extract a source IP from common alert shapes
+IPV4_RE = re.compile(r"\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d?\d)(?:\.|$)){4}\b")
+IPV6_RE = re.compile(r"\b([0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}\b")
+
+def pick_ip(alert):
+    # Preferred locations
+    prefer = [
+        ("data", "srcip"), ("data", "src_ip"), ("data", "source_ip"), ("data", "client_ip"),
+        ("srcip",), ("src_ip",), ("source_ip",), ("client_ip",),
+    ]
+    for path in prefer:
+        node = alert
+        ok = True
+        for k in path:
+            if isinstance(node, dict) and k in node:
+                node = node[k]
+            else:
+                ok = False; break
+        if ok and isinstance(node, str) and (IPV4_RE.search(node) or IPV6_RE.search(node)):
+            m = IPV4_RE.search(node) or IPV6_RE.search(node)
+            return m.group(0)
+
+    # Fallback: scan all string fields
+    def scan(obj):
+        if isinstance(obj, dict):
+            for v in obj.values():
+                ip = scan(v)
+                if ip: return ip
+        elif isinstance(obj, list):
+            for v in obj:
+                ip = scan(v)
+                if ip: return ip
+        elif isinstance(obj, str):
+            m = IPV4_RE.search(obj) or IPV6_RE.search(obj)
+            if m: return m.group(0)
+        return None
+
+    return scan(alert)
+
+
+def ts_age_days(ts):
+    if not ts:
+        return None
+    try:
+        then = datetime.fromtimestamp(int(ts), tz=timezone.utc)
+        now = datetime.now(timezone.utc)
+        return (now - then).total_seconds() / 86400.0
+    except Exception:
+        return None
+
+
+def vt_get(url, api_key):
+    headers = {"x-apikey": api_key, "accept": "application/json"}
+    return requests.get(url, headers=headers, timeout=timeout)
+
+
+def analyze_engine_results(last_analysis_results):
+    m = s = 0
+    weighted = 0.0
+    if isinstance(last_analysis_results, dict):
+        for _eng, res in last_analysis_results.items():
+            cat = (res or {}).get("category")
+            if cat == "malicious":
+                m += 1
+            elif cat == "suspicious":
+                s += 1
+            weighted += (1.0 if cat == "malicious" else (0.5 if cat == "suspicious" else 0.0))
+    return m, s, weighted
+
+
+def initial_verdict(mal, sus, rep, days):
+    if mal >= MAL_STRONG_MIN or (mal >= 1 and rep < REP_BAD_LT):
+        return "malicious"
+    if (mal + sus) >= 1:
+        if days is not None and days > STALE_WEAK_DAYS and rep >= REP_BAD_LT and mal <= 1:
+            return "unknown"  # stale weak hit
+        return "suspicious"
+    return "unknown"
+
+
+def apply_modifiers(verdict, weighted_mal, rep, tags, mal, sus):
+    # Engine-weight nudges
+    if verdict != "malicious":
+        if weighted_mal >= WEIGHT_MAL_STRONG:
+            verdict = "malicious"
+        elif weighted_mal >= WEIGHT_MAL_SUS and verdict == "unknown":
+            verdict = "suspicious"
+
+    # Risk tags: if any hit exists, don't let it drop below suspicious
+    if (mal + sus) >= 1 and (set(tags or []) & RISK_TAGS):
+        if verdict == "unknown":
+            verdict = "suspicious"
+    return verdict
+
+# ====================== VT request & message build =========================
+
+def request_virustotal_info(alert, api_key):
+    out = {"virustotal_ip": {}, "integration": "virustotal_ip"}
+
+    ip = pick_ip(alert)
+    if not ip:
+        debug("# No IP found in alert")
+        sys.exit(ERR_NO_IP_FOUND)
+        
+    # ---- Preserve requested original fields at TOP LEVEL ----
+    # These will appear as data.original_full_log
+    if "full_log" in alert:
+        out["original_full_log"] = alert["full_log"]
+
+    # ---- Example of preserving WAF data ----
+    # waf = (((alert.get("data") or {}).get("waf")) or {})
+    # waf_kept = {}
+    # for k in ("ref", "request", "src", "sip"):
+    #     if k in waf:
+    #         waf_kept[k] = waf[k]
+    # if waf_kept:
+    #     out["waf"] = waf_kept
+
+    # Retry loop
+    vt_body = None
+    for attempt in range(retries + 1):
+        try:
+            resp = vt_get(VT_IP_URL.format(ip=ip), api_key)
+            if resp.status_code == 429:
+                out["virustotal_ip"]["error"] = 429
+                out["virustotal_ip"]["description"] = "Error: VT rate limit"
+                send_msg(out, alert.get("agent"))
+                sys.exit(ERR_NO_RESPONSE_VT)
+            if resp.status_code == 401:
+                out["virustotal_ip"]["error"] = 401
+                out["virustotal_ip"]["description"] = "Error: Unauthorized (check API key)"
+                send_msg(out, alert.get("agent"))
+                sys.exit(ERR_NO_RESPONSE_VT)
+            if resp.status_code == 404:
+                vt_body = None
+                break
+            resp.raise_for_status()
+            vt_body = resp.json()
+            break
+        except Timeout:
+            debug(f"# Error: Request timed out. Remaining retries: {retries - attempt}")
+            continue
+        except RequestException as e:
+            debug(str(e))
+            sys.exit(ERR_NO_RESPONSE_VT)
+
+    # Prepare output base
+    src = {"alert_id": alert.get("id"), "rule": (alert.get("rule") or {}).get("id"), "ip": ip}
+    out["virustotal_ip"].update({"found": 0, "verdict": "unknown", "source": src})
+
+    if not vt_body or "data" not in vt_body:
+        return out  # not in corpus
+
+    attr = (vt_body.get("data") or {}).get("attributes") or {}
+    stats = attr.get("last_analysis_stats") or {}
+    mal = int(stats.get("malicious", 0) or 0)
+    sus = int(stats.get("suspicious", 0) or 0)
+    rep = int(attr.get("reputation", 0) or 0)
+    tags = attr.get("tags") or []
+    last_ts = attr.get("last_analysis_date")
+    days = ts_age_days(last_ts)
+
+    # Lightweight engine weighting
+    lar = attr.get("last_analysis_results") or {}
+    m_count, s_count, wmal = analyze_engine_results(lar)
+
+    verdict = initial_verdict(mal, sus, rep, days)
+    verdict = apply_modifiers(verdict, wmal, rep, tags, mal, sus)
+
+    # Build final block
+    out["virustotal_ip"]["found"] = 1
+    out["virustotal_ip"]["verdict"] = verdict
+    out["virustotal_ip"]["counts"] = {"malicious": mal, "suspicious": sus}
+    out["virustotal_ip"]["engine_counts"] = {"malicious": m_count, "suspicious": s_count}
+    out["virustotal_ip"]["weighted_malicious"] = round(wmal, 2)
+    out["virustotal_ip"]["reputation"] = rep
+    out["virustotal_ip"]["tags"] = tags
+    out["virustotal_ip"]["age_days"] = None if days is None else round(days, 1)
+    out["virustotal_ip"]["last_analysis_date"] = (
+        datetime.fromtimestamp(int(last_ts), tz=timezone.utc).isoformat() if last_ts else None
+    )
+    out["virustotal_ip"]["country"] = attr.get("country")
+    out["virustotal_ip"]["as_owner"] = attr.get("as_owner")
+    out["virustotal_ip"]["network"] = attr.get("network")
+    out["virustotal_ip"]["permalink"] = f"https://www.virustotal.com/gui/ip-address/{ip}"
+
+    # Flat line for rule matching
+    out["virustotal_ip"]["verdict_line"] = (
+        f"vt_ip verdict={verdict} ip={ip} mal={mal} sus={sus} "
+        f"wmal={round(wmal,2)} rep={rep} age_days={out['virustotal_ip']['age_days']} "
+        f"tags={','.join(tags[:5]) if tags else '-'} as_owner=\"{attr.get('as_owner')}\""
+    )
+
+    return out
+
+
+def send_msg(msg, agent=None):
+    if not agent or agent.get("id") == "000":
+        string = "1:virustotal_ip:{0}".format(json.dumps(msg))
+    else:
+        location = "[{0}] ({1}) {2}".format(agent["id"], agent["name"], agent["ip"] if "ip" in agent else "any")
+        location = location.replace("|", "||").replace(":", "|:")
+        string = "1:{0}->virustotal_ip:{1}".format(location, json.dumps(msg))
+
+    debug(f"# Request result from VT server: {string}")
+    try:
+        sock = socket(AF_UNIX, SOCK_DGRAM)
+        sock.connect(SOCKET_ADDR)
+        sock.send(string.encode())
+        sock.close()
+    except FileNotFoundError:
+        debug(f"# Error: Unable to open socket connection at {SOCKET_ADDR}")
+        sys.exit(ERR_SOCKET_OPERATION)
+
+# ================================= Entry ==================================
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/integrations/virustotal-ip/custom_virustotal.xml
+++ b/integrations/virustotal-ip/custom_virustotal.xml
@@ -1,0 +1,19 @@
+<group name="local,virustotal,sshd,">
+  <rule id="199901" level="12">
+    <if_sid>87100</if_sid>
+    <field name="virustotal_ip.verdict">^malicious$</field>
+    <description>Source IP flagged malicious by VirusTotal</description>
+  </rule>
+
+  <rule id="199902" level="7">
+    <if_sid>87100</if_sid>
+    <field name="virustotal_ip.verdict">^suspicious$</field>
+    <description>Source IP suspicious per VirusTotal</description>
+  </rule>
+
+  <rule id="199903" level="3">
+    <if_sid>87100</if_sid>
+    <field name="virustotal_ip.verdict">^unknown$</field>
+    <description>Source IP unknown per VirusTotal</description>
+  </rule>
+</group>


### PR DESCRIPTION
- Adds Wazuh integration for VirusTotal IP reputation enrichment, extracting source IPs from alerts and querying VT v3 API.
- Applies heuristic using engine consensus, reputation, age, and tags to classify IPs as malicious, suspicious, or unknown.
- Enriches alerts with JSON block (virustotal_ip) and flat verdict_line string for simplified rule matching and alerting.