### PR TITLE
feat: add kerberoast_mitigation integration with SOAR active response

### DIFF
--- a/integrations/kerberoast_mitigation/README.md
+++ b/integrations/kerberoast_mitigation/README.md
@@ -1,0 +1,280 @@
+\# Kerberoast Mitigation — Wazuh Integration
+
+
+
+\## Table of Contents
+
+\* \[Introduction](#introduction)
+
+\* \[Prerequisites](#prerequisites)
+
+\* \[Installation and Configuration](#installation-and-configuration)
+
+\* \[Integration Steps](#integration-steps)
+
+\* \[Integration Testing](#integration-testing)
+
+\* \[Sources](#sources)
+
+
+
+\---
+
+
+
+\## Introduction
+
+
+
+This integration provides automated detection and response for Kerberoasting
+
+attacks (MITRE ATT\&CK T1558.003) against Windows Active Directory environments.
+
+
+
+Kerberoasting allows any authenticated domain user to request a Kerberos service
+
+ticket for any SPN-registered account. The ticket is encrypted with the service
+
+account password hash and can be cracked offline with no further network
+
+interaction required after the initial request.
+
+
+
+The only viable detection window is the ticket request itself: Windows Security
+
+Event ID 4769. This integration filters on RC4-HMAC encryption type 0x17 (the
+
+downgrade forced by Impacket and Rubeus), ignoring legitimate AES traffic
+
+(0x11/0x12). Zero false positives against normal domain traffic.
+
+
+
+When Rule 100002 fires at Level 12, Wazuh Active Response executes
+
+kerb-block.ps1 on the Domain Controller, disabling the compromised service
+
+account via Disable-ADAccount. MTTR: hours to under 2 seconds.
+
+
+
+\---
+
+
+
+\## Prerequisites
+
+
+
+\- Wazuh Manager v4.x (tested on Wazuh Cloud v4.14.4)
+
+\- Wazuh Agent active on the Windows Domain Controller
+
+\- Windows Server 2019 Domain Controller with Active Directory Domain Services
+
+\- Sysmon v15.15 deployed on the Domain Controller
+
+\- RSAT (Remote Server Administration Tools) installed on the DC
+
+\- PowerShell execution policy allowing scripts on the DC
+
+\- Kerberos Service Ticket Operations auditing enabled via Group Policy:
+
+&#x20;   Computer Configuration > Advanced Audit Policy > Account Logon
+
+&#x20;   > Audit Kerberos Service Ticket Operations: Success and Failure
+
+\- At least one SPN-registered service account in the domain
+
+
+
+\---
+
+
+
+\## Installation and Configuration
+
+
+
+\### 1. Enable Kerberos Audit Policy
+
+
+
+On the Domain Controller, open Group Policy Management Console (GPMC):
+
+&#x20; Computer Configuration > Policies > Windows Settings > Security Settings
+
+&#x20; > Advanced Audit Policy Configuration > Account Logon
+
+&#x20; > Audit Kerberos Service Ticket Operations: Success and Failure
+
+
+
+Enforce and verify:
+
+&#x20; gpupdate /force
+
+&#x20; auditpol /get /subcategory:"Kerberos Service Ticket Operations"
+
+&#x20; # Expected output: Success and Failure
+
+
+
+\### 2. Deploy the Detection Rule
+
+
+
+Copy local\_rules.xml to the Wazuh Manager rules directory:
+
+&#x20; /var/ossec/etc/rules/local\_rules.xml
+
+
+
+Restart Wazuh Manager:
+
+&#x20; systemctl restart wazuh-manager
+
+
+
+\### 3. Deploy the Active Response Script
+
+
+
+Copy kerb-block.ps1 to the Active Response bin on the Domain Controller:
+
+&#x20; C:\\Program Files (x86)\\ossec-agent\\active-response\\bin\\kerb-block.ps1
+
+
+
+Add to ossec.conf on the Wazuh Manager:
+
+&#x20; <command>
+
+&#x20;   <n>win-disable-user</n>
+
+&#x20;   <executable>kerb-block.ps1</executable>
+
+&#x20;   <timeout\_allowed>no</timeout\_allowed>
+
+&#x20; </command>
+
+&#x20; <active-response>
+
+&#x20;   <command>win-disable-user</command>
+
+&#x20;   <location>local</location>
+
+&#x20;   <rules\_id>100002</rules\_id>
+
+&#x20; </active-response>
+
+
+
+Create audit log directory on the DC:
+
+&#x20; New-Item -ItemType Directory -Path C:\\Security -Force
+
+
+
+\---
+
+
+
+\## Integration Steps
+
+
+
+1\. Attacker requests a Kerberos ticket using Impacket GetUserSPNs,
+
+&#x20;  forcing RC4-HMAC (0x17) encryption.
+
+2\. Domain Controller generates Event ID 4769 with TicketEncryptionType 0x17.
+
+3\. Sysmon v15.15 and Windows Security Auditing forward events to Wazuh Agent.
+
+4\. Wazuh Agent forwards telemetry to Wazuh Manager.
+
+5\. Rule 100002 matches EventID 4769 + EncType 0x17, fires at Level 12.
+
+6\. Wazuh Active Response triggers kerb-block.ps1 via stdin on the DC.
+
+7\. Script parses alert JSON, calls Disable-ADAccount, writes to SOAR.log.
+
+
+
+\---
+
+
+
+\## Integration Testing
+
+
+
+\### Simulate the Attack
+
+
+
+From a Kali Linux machine on the same subnet:
+
+&#x20; impacket-GetUserSPNs DOMAIN/username:password -dc-ip DC\_IP -request
+
+
+
+\### Verify Detection
+
+
+
+Check Wazuh Manager for Rule 100002 firing at Level 12 (MITRE T1558.003).
+
+
+
+\### Verify Automated Response
+
+
+
+On the Domain Controller:
+
+&#x20; Get-ADUser sql\_service | Select-Object Name, Enabled
+
+&#x20; # Expected: Enabled : False
+
+
+
+&#x20; Get-Content C:\\Security\\SOAR.log
+
+&#x20; # Expected: \[timestamp] - SUCCESS: Disabled account: sql\_service
+
+
+
+\---
+
+
+
+\## Sources
+
+
+
+\- MITRE ATT\&CK T1558.003: https://attack.mitre.org/techniques/T1558/003/
+
+\- Wazuh Active Response: https://documentation.wazuh.com/current/user-manual/
+
+&#x20; capabilities/active-response/
+
+\- Windows Event 4769: https://learn.microsoft.com/en-us/windows/security/
+
+&#x20; threat-protection/auditing/event-4769
+
+\- Full lab implementation and evidence:
+
+&#x20; https://github.com/R-Williams-Security/Kerberoast-Detection-Lab
+
+\- Portfolio write-up:
+
+&#x20; https://sites.google.com/view/williamsransom-portfolio/project-page/
+
+&#x20; active-directory-soar-automated-kerberoast-mitigation
+
+
+

--- a/integrations/kerberoast_mitigation/README.md
+++ b/integrations/kerberoast_mitigation/README.md
@@ -1,280 +1,159 @@
-\# Kerberoast Mitigation — Wazuh Integration
+# Kerberoast Mitigation - Wazuh Integration
 
+## Table of Contents
 
+* [Introduction](#introduction)
+* [Prerequisites](#prerequisites)
+* [Installation and Configuration](#installation-and-configuration)
+* [Integration Steps](#integration-steps)
+* [Integration Testing](#integration-testing)
+* [Sources](#sources)
 
-\## Table of Contents
+---
 
-\* \[Introduction](#introduction)
-
-\* \[Prerequisites](#prerequisites)
-
-\* \[Installation and Configuration](#installation-and-configuration)
-
-\* \[Integration Steps](#integration-steps)
-
-\* \[Integration Testing](#integration-testing)
-
-\* \[Sources](#sources)
-
-
-
-\---
-
-
-
-\## Introduction
-
-
+## Introduction
 
 This integration provides automated detection and response for Kerberoasting
-
-attacks (MITRE ATT\&CK T1558.003) against Windows Active Directory environments.
-
-
+attacks (MITRE ATT&CK T1558.003) against Windows Active Directory environments.
 
 Kerberoasting allows any authenticated domain user to request a Kerberos service
-
 ticket for any SPN-registered account. The ticket is encrypted with the service
-
 account password hash and can be cracked offline with no further network
-
 interaction required after the initial request.
 
-
-
 The only viable detection window is the ticket request itself: Windows Security
-
 Event ID 4769. This integration filters on RC4-HMAC encryption type 0x17 (the
-
 downgrade forced by Impacket and Rubeus), ignoring legitimate AES traffic
-
 (0x11/0x12). Zero false positives against normal domain traffic.
 
-
-
 When Rule 100002 fires at Level 12, Wazuh Active Response executes
-
 kerb-block.ps1 on the Domain Controller, disabling the compromised service
+account via Disable-ADAccount. Mean Time to Remediate: hours to under 2 seconds.
 
-account via Disable-ADAccount. MTTR: hours to under 2 seconds.
+---
 
+## Prerequisites
 
+- Wazuh Manager v4.x (tested on Wazuh Cloud v4.14.4)
+- Wazuh Agent active and connected on the Windows Domain Controller
+- Windows Server 2019 Domain Controller with Active Directory Domain Services
+- Sysmon v15.15 deployed on the Domain Controller
+- RSAT (Remote Server Administration Tools) installed on the Domain Controller
+- PowerShell execution policy allowing script execution on the Domain Controller
+- Kerberos Service Ticket Operations auditing enabled via Group Policy:
+    Computer Configuration > Advanced Audit Policy Configuration > Account Logon
+    > Audit Kerberos Service Ticket Operations: Success and Failure
+- At least one SPN-registered service account present in the domain
 
-\---
+---
 
+## Installation and Configuration
 
-
-\## Prerequisites
-
-
-
-\- Wazuh Manager v4.x (tested on Wazuh Cloud v4.14.4)
-
-\- Wazuh Agent active on the Windows Domain Controller
-
-\- Windows Server 2019 Domain Controller with Active Directory Domain Services
-
-\- Sysmon v15.15 deployed on the Domain Controller
-
-\- RSAT (Remote Server Administration Tools) installed on the DC
-
-\- PowerShell execution policy allowing scripts on the DC
-
-\- Kerberos Service Ticket Operations auditing enabled via Group Policy:
-
-&#x20;   Computer Configuration > Advanced Audit Policy > Account Logon
-
-&#x20;   > Audit Kerberos Service Ticket Operations: Success and Failure
-
-\- At least one SPN-registered service account in the domain
-
-
-
-\---
-
-
-
-\## Installation and Configuration
-
-
-
-\### 1. Enable Kerberos Audit Policy
-
-
+### 1. Enable Kerberos Audit Policy
 
 On the Domain Controller, open Group Policy Management Console (GPMC):
 
-&#x20; Computer Configuration > Policies > Windows Settings > Security Settings
-
-&#x20; > Advanced Audit Policy Configuration > Account Logon
-
-&#x20; > Audit Kerberos Service Ticket Operations: Success and Failure
-
-
+    Computer Configuration > Policies > Windows Settings > Security Settings
+    > Advanced Audit Policy Configuration > Account Logon
+    > Audit Kerberos Service Ticket Operations: Success and Failure
 
 Enforce and verify:
 
-&#x20; gpupdate /force
+    gpupdate /force
+    auditpol /get /subcategory:"Kerberos Service Ticket Operations"
+    # Expected output: Success and Failure
 
-&#x20; auditpol /get /subcategory:"Kerberos Service Ticket Operations"
+Without this policy, Event ID 4769 is never generated and the detection
+pipeline has no telemetry to act on.
 
-&#x20; # Expected output: Success and Failure
+### 2. Deploy the Detection Rule
 
+Copy local_rules.xml to the Wazuh Manager rules directory:
 
-
-\### 2. Deploy the Detection Rule
-
-
-
-Copy local\_rules.xml to the Wazuh Manager rules directory:
-
-&#x20; /var/ossec/etc/rules/local\_rules.xml
-
-
+    /var/ossec/etc/rules/local_rules.xml
 
 Restart Wazuh Manager:
 
-&#x20; systemctl restart wazuh-manager
+    systemctl restart wazuh-manager
 
+### 3. Deploy the Active Response Script
 
+Copy kerb-block.ps1 to the Active Response bin directory on the Domain Controller:
 
-\### 3. Deploy the Active Response Script
+    C:\Program Files (x86)\ossec-agent\active-response\bin\kerb-block.ps1
 
+Add the following configuration to ossec.conf on the Wazuh Manager:
 
+    <command>
+      <name>win-disable-user</name>
+      <executable>kerb-block.ps1</executable>
+      <timeout_allowed>no</timeout_allowed>
+    </command>
 
-Copy kerb-block.ps1 to the Active Response bin on the Domain Controller:
+    <active-response>
+      <command>win-disable-user</command>
+      <location>local</location>
+      <rules_id>100002</rules_id>
+    </active-response>
 
-&#x20; C:\\Program Files (x86)\\ossec-agent\\active-response\\bin\\kerb-block.ps1
+Restart Wazuh Manager after configuration changes:
 
+    systemctl restart wazuh-manager
 
+---
 
-Add to ossec.conf on the Wazuh Manager:
+## Integration Steps
 
-&#x20; <command>
+1. Attacker requests a Kerberos service ticket using Impacket GetUserSPNs,
+   forcing RC4-HMAC (0x17) encryption downgrade.
+2. Domain Controller generates Windows Security Event ID 4769 with
+   TicketEncryptionType 0x17.
+3. Sysmon v15.15 and Windows Security Auditing forward events to the Wazuh Agent.
+4. Wazuh Agent forwards telemetry to Wazuh Manager.
+5. Rule 100002 matches EventID 4769 with EncryptionType 0x17 and fires at Level 12.
+6. Wazuh Active Response triggers kerb-block.ps1 via stdin on the Domain Controller.
+7. Script parses alert JSON, calls Disable-ADAccount, writes timestamped entry
+   to C:\Security\SOAR.log.
 
-&#x20;   <n>win-disable-user</n>
+---
 
-&#x20;   <executable>kerb-block.ps1</executable>
+## Integration Testing
 
-&#x20;   <timeout\_allowed>no</timeout\_allowed>
+### Simulate the Attack
 
-&#x20; </command>
+From a Kali Linux machine on the same network segment:
 
-&#x20; <active-response>
+    impacket-GetUserSPNs DOMAIN/username:password -dc-ip DC_IP -request
 
-&#x20;   <command>win-disable-user</command>
+This forces an RC4 ticket request against all SPN-registered accounts.
 
-&#x20;   <location>local</location>
+### Verify Detection
 
-&#x20;   <rules\_id>100002</rules\_id>
+Check Wazuh Manager for Rule 100002 firing at Level 12 with MITRE T1558.003.
 
-&#x20; </active-response>
+### Verify Automated Response
 
+On the Domain Controller, confirm account status:
 
+    Get-ADUser sql_service | Select-Object Name, Enabled
+    # Expected: Enabled : False
 
-Create audit log directory on the DC:
+Review the audit log:
 
-&#x20; New-Item -ItemType Directory -Path C:\\Security -Force
+    Get-Content C:\Security\SOAR.log
+    # Expected: [timestamp] - SUCCESS: Disabled account: sql_service
 
+---
 
+## Sources
 
-\---
-
-
-
-\## Integration Steps
-
-
-
-1\. Attacker requests a Kerberos ticket using Impacket GetUserSPNs,
-
-&#x20;  forcing RC4-HMAC (0x17) encryption.
-
-2\. Domain Controller generates Event ID 4769 with TicketEncryptionType 0x17.
-
-3\. Sysmon v15.15 and Windows Security Auditing forward events to Wazuh Agent.
-
-4\. Wazuh Agent forwards telemetry to Wazuh Manager.
-
-5\. Rule 100002 matches EventID 4769 + EncType 0x17, fires at Level 12.
-
-6\. Wazuh Active Response triggers kerb-block.ps1 via stdin on the DC.
-
-7\. Script parses alert JSON, calls Disable-ADAccount, writes to SOAR.log.
-
-
-
-\---
-
-
-
-\## Integration Testing
-
-
-
-\### Simulate the Attack
-
-
-
-From a Kali Linux machine on the same subnet:
-
-&#x20; impacket-GetUserSPNs DOMAIN/username:password -dc-ip DC\_IP -request
-
-
-
-\### Verify Detection
-
-
-
-Check Wazuh Manager for Rule 100002 firing at Level 12 (MITRE T1558.003).
-
-
-
-\### Verify Automated Response
-
-
-
-On the Domain Controller:
-
-&#x20; Get-ADUser sql\_service | Select-Object Name, Enabled
-
-&#x20; # Expected: Enabled : False
-
-
-
-&#x20; Get-Content C:\\Security\\SOAR.log
-
-&#x20; # Expected: \[timestamp] - SUCCESS: Disabled account: sql\_service
-
-
-
-\---
-
-
-
-\## Sources
-
-
-
-\- MITRE ATT\&CK T1558.003: https://attack.mitre.org/techniques/T1558/003/
-
-\- Wazuh Active Response: https://documentation.wazuh.com/current/user-manual/
-
-&#x20; capabilities/active-response/
-
-\- Windows Event 4769: https://learn.microsoft.com/en-us/windows/security/
-
-&#x20; threat-protection/auditing/event-4769
-
-\- Full lab implementation and evidence:
-
-&#x20; https://github.com/R-Williams-Security/Kerberoast-Detection-Lab
-
-\- Portfolio write-up:
-
-&#x20; https://sites.google.com/view/williamsransom-portfolio/project-page/
-
-&#x20; active-directory-soar-automated-kerberoast-mitigation
-
-
-
+- MITRE ATT&CK T1558.003:
+  https://attack.mitre.org/techniques/T1558/003/
+- Wazuh Active Response documentation:
+  https://documentation.wazuh.com/current/user-manual/capabilities/active-response/
+- Windows Security Event ID 4769:
+  https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4769
+- Full lab implementation and evidence:
+  https://github.com/R-Williams-Security/Kerberoast-Detection-Lab
+- Portfolio write-up:
+  https://sites.google.com/view/williamsransom-portfolio/project-page/active-directory-soar-automated-kerberoast-mitigation

--- a/integrations/kerberoast_mitigation/README.md
+++ b/integrations/kerberoast_mitigation/README.md
@@ -41,8 +41,8 @@ account via Disable-ADAccount. Mean Time to Remediate: hours to under 2 seconds.
 - RSAT (Remote Server Administration Tools) installed on the Domain Controller
 - PowerShell execution policy allowing script execution on the Domain Controller
 - Kerberos Service Ticket Operations auditing enabled via Group Policy:
-    Computer Configuration > Advanced Audit Policy Configuration > Account Logon
-    > Audit Kerberos Service Ticket Operations: Success and Failure
+  Computer Configuration > Advanced Audit Policy Configuration > Account Logon
+  > Audit Kerberos Service Ticket Operations: Success and Failure
 - At least one SPN-registered service account present in the domain
 
 ---
@@ -84,17 +84,17 @@ Copy kerb-block.ps1 to the Active Response bin directory on the Domain Controlle
 
 Add the following configuration to ossec.conf on the Wazuh Manager:
 
-    <command>
-      <name>win-disable-user</name>
-      <executable>kerb-block.ps1</executable>
-      <timeout_allowed>no</timeout_allowed>
-    </command>
+    
+      win-disable-user
+      kerb-block.ps1
+      no
+    
 
-    <active-response>
-      <command>win-disable-user</command>
-      <location>local</location>
-      <rules_id>100002</rules_id>
-    </active-response>
+    
+      win-disable-user
+      local
+      100002
+    
 
 Restart Wazuh Manager after configuration changes:
 
@@ -112,8 +112,8 @@ Restart Wazuh Manager after configuration changes:
 4. Wazuh Agent forwards telemetry to Wazuh Manager.
 5. Rule 100002 matches EventID 4769 with EncryptionType 0x17 and fires at Level 12.
 6. Wazuh Active Response triggers kerb-block.ps1 via stdin on the Domain Controller.
-7. Script parses alert JSON, calls Disable-ADAccount, writes timestamped entry
-   to C:\Security\SOAR.log.
+7. Script checks the command field, extracts the target account, calls
+   Disable-ADAccount, and writes a timestamped entry to C:\Security\SOAR.log.
 
 ---
 

--- a/integrations/kerberoast_mitigation/active-response/kerb-block.ps1
+++ b/integrations/kerberoast_mitigation/active-response/kerb-block.ps1
@@ -3,7 +3,7 @@
 
 $logPath = "C:\Security\SOAR.log"
 
-# Ensure log directory exists
+# Ensure log directory exists before any writes
 if (-not (Test-Path "C:\Security")) {
     New-Item -ItemType Directory -Path "C:\Security" -Force | Out-Null
 }
@@ -15,18 +15,32 @@ try {
 
     if ([string]::IsNullOrWhiteSpace($inputData)) {
         "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - ERROR: No input received from Wazuh" |
-        Out-File -FilePath $logPath -Append
+            Out-File -FilePath $logPath -Append
         exit 1
     }
 
-    # Parse the JSON alert - with error handling for malformed input
+    # Parse the JSON alert with dedicated error handling for malformed input
     try {
         $alert = $inputData | ConvertFrom-Json
     }
     catch {
         "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - ERROR: Failed to parse alert JSON. Raw input: $inputData" |
-        Out-File -FilePath $logPath -Append
+            Out-File -FilePath $logPath -Append
         exit 1
+    }
+
+    # Check the Wazuh active-response command field (add / delete)
+    # Only perform the disable action for the 'add' command
+    $command = $alert.command
+    if ([string]::IsNullOrWhiteSpace($command)) {
+        "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - ERROR: No command field in Wazuh active-response payload" |
+            Out-File -FilePath $logPath -Append
+        exit 1
+    }
+    if ($command -ne 'add') {
+        "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - INFO: Ignoring command '$command' - no account action taken" |
+            Out-File -FilePath $logPath -Append
+        exit 0
     }
 
     # Extract the targeted service account from the alert data
@@ -34,7 +48,7 @@ try {
 
     if ([string]::IsNullOrWhiteSpace($targetAccount)) {
         "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - ERROR: Could not extract target account from alert JSON" |
-        Out-File -FilePath $logPath -Append
+            Out-File -FilePath $logPath -Append
         exit 1
     }
 
@@ -46,12 +60,12 @@ try {
 
     # Write success audit entry to SOAR log
     "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - SUCCESS: Disabled account: $targetAccount" |
-    Out-File -FilePath $logPath -Append
+        Out-File -FilePath $logPath -Append
 
     exit 0
 }
 catch {
     "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - ERROR: $($_.Exception.Message)" |
-    Out-File -FilePath $logPath -Append
+        Out-File -FilePath $logPath -Append
     exit 1
 }

--- a/integrations/kerberoast_mitigation/active-response/kerb-block.ps1
+++ b/integrations/kerberoast_mitigation/active-response/kerb-block.ps1
@@ -1,7 +1,12 @@
 # kerb-block.ps1
-# Wazuh Active Response script — receives alert via stdin, disables the targeted AD account
+# Wazuh Active Response script - receives alert via stdin, disables the targeted AD account
 
 $logPath = "C:\Security\SOAR.log"
+
+# Ensure log directory exists
+if (-not (Test-Path "C:\Security")) {
+    New-Item -ItemType Directory -Path "C:\Security" -Force | Out-Null
+}
 
 try {
     # Wazuh passes the alert JSON to the script via standard input (stdin)
@@ -10,39 +15,43 @@ try {
 
     if ([string]::IsNullOrWhiteSpace($inputData)) {
         "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - ERROR: No input received from Wazuh" |
-            Out-File -FilePath $logPath -Append
-        exit 1
-    }
-
-    # Parse the JSON alert
-    $alert = $inputData | ConvertFrom-Json
-
-    # Extract the username from the Kerberos ticket event
-    $targetUser = $alert.parameters.alert.data.win.eventdata.TargetUserName
-
-    if ([string]::IsNullOrWhiteSpace($targetUser)) {
-        "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - ERROR: Could not extract TargetUserName from alert" |
-            Out-File -FilePath $logPath -Append
-        exit 1
-    }
-
-    # Skip built-in accounts to avoid locking out the domain
-    $builtinAccounts = @('Administrator','krbtgt','ANONYMOUS LOGON')
-    if ($builtinAccounts -contains $targetUser) {
-        "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - SKIPPED built-in account: $targetUser" |
-            Out-File -FilePath $logPath -Append
-        exit 0
-    }
-
-    # Disable the account
-    Import-Module ActiveDirectory
-    Disable-ADAccount -Identity $targetUser -ErrorAction Stop
-
-    "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - SUCCESS: Disabled account: $targetUser" |
         Out-File -FilePath $logPath -Append
+        exit 1
+    }
+
+    # Parse the JSON alert - with error handling for malformed input
+    try {
+        $alert = $inputData | ConvertFrom-Json
+    }
+    catch {
+        "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - ERROR: Failed to parse alert JSON. Raw input: $inputData" |
+        Out-File -FilePath $logPath -Append
+        exit 1
+    }
+
+    # Extract the targeted service account from the alert data
+    $targetAccount = $alert.data.win.eventdata.targetUserName
+
+    if ([string]::IsNullOrWhiteSpace($targetAccount)) {
+        "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - ERROR: Could not extract target account from alert JSON" |
+        Out-File -FilePath $logPath -Append
+        exit 1
+    }
+
+    # Import Active Directory module (requires RSAT on the Domain Controller)
+    Import-Module ActiveDirectory -ErrorAction Stop
+
+    # Disable the compromised service account
+    Disable-ADAccount -Identity $targetAccount -ErrorAction Stop
+
+    # Write success audit entry to SOAR log
+    "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - SUCCESS: Disabled account: $targetAccount" |
+    Out-File -FilePath $logPath -Append
+
+    exit 0
 }
 catch {
     "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - ERROR: $($_.Exception.Message)" |
-        Out-File -FilePath $logPath -Append
+    Out-File -FilePath $logPath -Append
     exit 1
 }

--- a/integrations/kerberoast_mitigation/active-response/kerb-block.ps1
+++ b/integrations/kerberoast_mitigation/active-response/kerb-block.ps1
@@ -1,0 +1,48 @@
+# kerb-block.ps1
+# Wazuh Active Response script — receives alert via stdin, disables the targeted AD account
+
+$logPath = "C:\Security\SOAR.log"
+
+try {
+    # Wazuh passes the alert JSON to the script via standard input (stdin)
+    $inputData = $null
+    $inputData = [Console]::In.ReadToEnd()
+
+    if ([string]::IsNullOrWhiteSpace($inputData)) {
+        "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - ERROR: No input received from Wazuh" |
+            Out-File -FilePath $logPath -Append
+        exit 1
+    }
+
+    # Parse the JSON alert
+    $alert = $inputData | ConvertFrom-Json
+
+    # Extract the username from the Kerberos ticket event
+    $targetUser = $alert.parameters.alert.data.win.eventdata.TargetUserName
+
+    if ([string]::IsNullOrWhiteSpace($targetUser)) {
+        "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - ERROR: Could not extract TargetUserName from alert" |
+            Out-File -FilePath $logPath -Append
+        exit 1
+    }
+
+    # Skip built-in accounts to avoid locking out the domain
+    $builtinAccounts = @('Administrator','krbtgt','ANONYMOUS LOGON')
+    if ($builtinAccounts -contains $targetUser) {
+        "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - SKIPPED built-in account: $targetUser" |
+            Out-File -FilePath $logPath -Append
+        exit 0
+    }
+
+    # Disable the account
+    Import-Module ActiveDirectory
+    Disable-ADAccount -Identity $targetUser -ErrorAction Stop
+
+    "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - SUCCESS: Disabled account: $targetUser" |
+        Out-File -FilePath $logPath -Append
+}
+catch {
+    "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') - ERROR: $($_.Exception.Message)" |
+        Out-File -FilePath $logPath -Append
+    exit 1
+}

--- a/integrations/kerberoast_mitigation/ruleset/rules/local_rules.xml
+++ b/integrations/kerberoast_mitigation/ruleset/rules/local_rules.xml
@@ -1,0 +1,16 @@
+<group name="kerberoast_detection">
+
+  <!-- Kerberoasting: Service ticket requested using RC4 encryption (0x17) -->
+  <!-- RC4 is legacy and only used by attacker tools like Impacket by default -->
+  <!-- Legitimate modern requests use AES (0x11 or 0x12) -->
+  <rule id="100002" level="12">
+    <if_sid>60103</if_sid>
+    <field name="win.system.eventID">^4769$</field>
+    <field name="win.eventdata.ticketEncryptionType">^0x17$</field>
+    <description>Kerberoasting Attack: RC4 service ticket request detected (T1558.003)</description>
+    <mitre>
+      <id>T1558.003</id>
+    </mitre>
+  </rule>
+
+</group>


### PR DESCRIPTION
# Summary
This PR adds a new integration for automated detection and response to **Kerberoasting attacks** (MITRE ATT&CK T1558.003) in Windows Active Directory.

## Components
* **ruleset/rules/local_rules.xml**: 
    * **Rule 100002**: Detects RC4 downgrade (Event ID 4769, EncType 0x17) at Level 12.
    * **Mapping**: MITRE T1558.003.
    * **Efficiency**: Zero false positives against legitimate AES traffic (0x11/0x12).
* **active-response/kerb-block.ps1**: 
    * PowerShell SOAR script that parses Wazuh alert JSON via `stdin`.
    * Calls `Disable-ADAccount` via RSAT and writes audit entries to `C:\Security\SOAR.log`.
    * **Impact**: Reduced MTTR from hours to under 2 seconds.

## Evidence
Built and tested against a live lab: 
* **OS**: Windows Server 2019
* **Tools**: Wazuh Cloud v4.14.4, Sysmon v15.15, Impacket `GetUserSPNs`.
* **Full Lab Documentation**: [Kerberoast-Detection-Lab](https://github.com/R-Williams-Security/Kerberoast-Detection-Lab)

## Testing
Tested end-to-end: 
1.  **Attack Simulation**: Confirmed Event ID 4769 generated.
2.  **Detection**: Rule 100002 successfully fired.
3.  **Active Response**: `kerb-block.ps1` executed.
4.  **Verification**: `sql_service` Enabled: **False** confirmed; `SOAR.log` entry written.

---
*I have followed the repository `CONTRIBUTING.md` guidelines and am open to any feedback or changes required for merging.*
