### PR TITLE
Add Whisper threat-intelligence enrichment integration

### DIFF
--- a/integrations/whisper/README.md
+++ b/integrations/whisper/README.md
@@ -1,102 +1,114 @@
-# Wazuh – Whisper Threat-Intelligence Enrichment Integration
+# Whisper-Wazuh Integration
 
 Enrich Wazuh alerts with relationship context from the [Whisper](https://www.whisper.security)
 infrastructure graph — the internet modeled as one connected graph (ASNs, prefixes, DNS, WHOIS,
-threat feeds, Tor relays, TLS fingerprints). When an alert carries a public IP or domain, this
-integration asks the graph what it knows and writes the answer back into Wazuh as a new,
-evidence-graded alert.
-
-> **This is the enrichment tier — it needs no API key** (the Whisper graph is queried anonymously).
-> Whisper also ships a *keyed* tier (an agent-activity log source) and an on-demand investigation
-> CLI, plus packaged installers (`.deb`/`.rpm`, a one-line bootstrap). Those live in the upstream
-> project — see [Beyond enrichment](#beyond-enrichment--the-keyed-tier) and
-> **https://github.com/whisper-sec/whisper-wazuh**.
+threat feeds, Tor relays, TLS fingerprints).
 
 ## Table of Contents
 
-- [Introduction](#introduction)
-- [Verdict → alert level](#verdict--alert-level)
-- [Installation and Configuration](#installation-and-configuration)
-- [Wazuh Configuration](#wazuh-configuration)
-  - [Integrator Config (manager `ossec.conf`)](#integrator-config-manager-ossecconf)
-  - [Custom Rules](#custom-rules)
-  - [Manual Tests](#manual-tests)
-- [Beyond enrichment — the keyed tier](#beyond-enrichment--the-keyed-tier)
-- [Sources](#sources)
+* [Introduction](#introduction)
+* [Prerequisites](#prerequisites)
+* [Installation and Configuration](#installation-and-configuration)
+    * [Installing Whisper](#installing-whisper)
+    * [Initial Whisper Configuration](#initial-whisper-configuration)
+    * [Installing Wazuh (if applicable)](#installing-wazuh-if-applicable)
+    * [Initial Wazuh Configuration (if applicable)](#initial-wazuh-configuration-if-applicable)
+    * [Using the Integration Files](#using-the-integration-files)
+* [Integration Steps](#integration-steps)
+* [Integration Testing](#integration-testing)
+* [Sources](#sources)
+
+---
 
 ## Introduction
 
-This integration:
+When a Wazuh alert carries a public IP or domain, this integration asks the Whisper graph what it
+knows about that indicator and writes the answer back into Wazuh as a new, evidence-graded alert
+under `data.whisper.*` — verdict (`known_bad` / `suspicious` / `known_good` / `unknown`), risk score,
+threat feeds, ASN + reputation, prefix threat, geo; for domains also DNS / WHOIS / SPF / lookalikes.
+The verdict is derived from *evidence* (threat-feed categories + confirmed-malicious node flags),
+never copied from the raw score — "trust never overrides threat" — and a bundled rule maps it to a
+Wazuh alert level.
 
-- Extracts a **public IP or domain** from matching Wazuh alerts (flexible field-path detection across
-  `data.srcip`, Suricata/Cloudflare/GuardDuty/Security-Lake paths, etc.).
-- Queries the **Whisper graph** (`POST https://graph.whisper.security/api/query`) for an
-  evidence-based threat verdict — **no API key required** for these graph lookups.
-- Derives the **verdict from evidence** (threat-feed categories + confirmed-malicious node flags),
-  never copied from the raw score — *"trust never overrides threat."*
-- Writes back a new alert under `data.whisper.*`: verdict, risk score, level, threat feeds, tags,
-  ASN + reputation, prefix + registered-prefix threat, geo; for domains also DNS / WHOIS / SPF /
-  web-links / lookalike variants.
-- Links each enrichment to its triggering alert via `source_ref`, and de-duplicates repeat
-  indicators with a small SQLite cache (no re-lookup within a TTL).
-- Handles API / transport / auth errors gracefully, emitting typed error alerts rather than crashing.
+It is a Pattern-A `integratord` custom script — stdlib-only Python on the manager's bundled
+interpreter — and the graph enrichment is **keyless** (no API key required).
 
-## Verdict → alert level
+> A *keyed* tier (an agent-activity log source) and an on-demand investigation CLI, plus packaged
+> installers, live in the upstream project: <https://github.com/whisper-sec/whisper-wazuh>.
 
-The verdict is evidence-derived and mapped to a Wazuh alert level by the bundled rules
-(`whisper_rules.xml`):
+---
 
-| Verdict | Meaning | Rule | Level |
-|---|---|---|---|
-| `known_bad` | confirmed-malicious evidence (C2 / malware / phishing feed or node flag) | 100201 | 12 |
-| `known_bad` (CRITICAL) | as above, with a critical graph score | 100205 | 14 |
-| `suspicious` | a threat signal without a confirmed-bad category (e.g. Tor / anonymizer / blocklist) | 100202 | 7 |
-| `known_good` | allowlist-vouched, no threat | 100203 | 3 |
-| `unknown` | no data at this granularity (no-data ≠ safe) | 100204 | 3 |
+## Prerequisites
 
-Opt-in: rule **100206** flags a Cobalt-Strike TLS fingerprint (JARM) when the integration's
-`extra_enrichments` option includes `tls_fingerprint`.
+* **Wazuh Server (manager) 4.x** — tested on 4.14.5.
+* The manager's **bundled Python 3.10** — the connector is standard-library only; nothing to
+  `pip install`.
+* **TLS egress** from the manager to `graph.whisper.security` (the graph API).
+* The **Wazuh indexer reachable** from the manager, to install the field-type template.
+* **No API key** — the graph enrichment is queried anonymously. (The upstream *keyed* features need a
+  Whisper API key; see [Sources](#sources).)
+
+---
 
 ## Installation and Configuration
 
-The integration is **stdlib-only Python** on the manager's bundled interpreter — nothing to
-`pip install`. It ships five files:
+### Installing Whisper
+
+Nothing to install — Whisper is a hosted service. The connector queries the graph at
+`https://graph.whisper.security`; you only need TLS egress to it from the manager (see
+[Prerequisites](#prerequisites)).
+
+### Initial Whisper Configuration
+
+None. The graph enrichment is keyless, so there is no account, API key, or console setup.
+
+### Installing Wazuh (if applicable)
+
+A standard Wazuh installation is assumed. See the official
+[Wazuh installation guide](https://documentation.wazuh.com/current/installation-guide/index.html).
+
+### Initial Wazuh Configuration (if applicable)
+
+No special configuration is required beyond a standard manager.
+
+### Using the Integration Files
+
+This integration ships five files:
 
 | File | Destination | Perms |
 |---|---|---|
 | `custom-whisper` (shell wrapper) | `/var/ossec/integrations/` | 750 `root:wazuh` |
-| `custom-whisper.py` (the connector) | `/var/ossec/integrations/` | 750 `root:wazuh` |
-| `whisper_client.py` (shared HTTP/TLS client — **imported** by the connector) | `/var/ossec/integrations/` | 640 `root:wazuh` |
+| `custom-whisper.py` (connector) | `/var/ossec/integrations/` | 750 `root:wazuh` |
+| `whisper_client.py` (shared HTTP/TLS client — imported by the connector) | `/var/ossec/integrations/` | 640 `root:wazuh` |
 | `whisper_rules.xml` | `/var/ossec/etc/rules/` | 660 `root:wazuh` |
 | `whisper-template.json` (indexer field types) | PUT to the indexer | — |
 
+**1. Scripts** (the connector imports `whisper_client.py`, so all three go together):
+
 ```bash
-# 1. scripts (the connector imports whisper_client.py, so all three go together)
 cp custom-whisper custom-whisper.py whisper_client.py /var/ossec/integrations/
 chown root:wazuh /var/ossec/integrations/custom-whisper /var/ossec/integrations/custom-whisper.py /var/ossec/integrations/whisper_client.py
 chmod 750 /var/ossec/integrations/custom-whisper /var/ossec/integrations/custom-whisper.py
 chmod 640 /var/ossec/integrations/whisper_client.py
+```
 
-# 2. rules
+**2. Rules:**
+
+```bash
 cp whisper_rules.xml /var/ossec/etc/rules/
 chown root:wazuh /var/ossec/etc/rules/whisper_rules.xml && chmod 660 /var/ossec/etc/rules/whisper_rules.xml
+```
 
-# 3. indexer field types (analysisd stringifies every value; the template coerces
-#    data.whisper.* numbers/booleans back so range queries work)
+**3. Indexer field types** (analysisd stringifies every value; the template coerces `data.whisper.*`
+numbers/booleans back so range queries work):
+
+```bash
 curl -sk -u <indexer-user>:<indexer-pass> -XPUT "https://<indexer>:9200/_template/whisper" \
   -H 'Content-Type: application/json' -d @whisper-template.json
 ```
 
-> The upstream project ships an `install.sh` that does all of the above with an `ossec.conf`
-> rollback and a post-restart verify, plus `.deb`/`.rpm` packages and a one-line bootstrap. If you
-> want the turnkey path, use it: <https://github.com/whisper-sec/whisper-wazuh#install>.
-
-## Wazuh Configuration
-
-### Integrator Config (manager `ossec.conf`)
-
-Add an `<integration>` block. There is **no `<api_key>`** — the graph enrichment is keyless. The
-`<name>` must match the shell wrapper.
+**4. Register the integration** in the manager's `/var/ossec/etc/ossec.conf`. There is **no
+`<api_key>`** — the enrichment is keyless. `<name>` must match the shell wrapper:
 
 ```xml
 <integration>
@@ -107,60 +119,65 @@ Add an `<integration>` block. There is **no `<api_key>`** — the graph enrichme
 ```
 
 `<group>` (or `<rule_id>`) is your cost/noise dial: every matching alert that carries a public IP or
-domain becomes one graph lookup (deduped by the cache). Start narrow (e.g. `sshd`) and widen
-deliberately. **Never** point it at a group the enrichment alerts themselves carry — that would loop.
+domain becomes one graph lookup (deduped by a small cache). Start narrow (e.g. `sshd`) and widen
+deliberately. Never point it at a group the enrichment alerts themselves carry.
 
-Then restart the manager: `sudo /var/ossec/bin/wazuh-control restart`.
-
-### Custom Rules
-
-`whisper_rules.xml` renders the verdict as an alert level (see the table above). It installs to
-`/var/ossec/etc/rules/` and is picked up on the next manager restart. Without it, an enrichment is
-just a decoded event with no severity.
-
-### Manual Tests
-
-Turn on the connector's debug log first:
+**5. Restart the manager** after these changes:
 
 ```bash
-echo 'integrator.debug=2' | sudo tee -a /var/ossec/etc/local_internal_options.conf
-sudo /var/ossec/bin/wazuh-control restart
+systemctl restart wazuh-manager   # or: /var/ossec/bin/wazuh-control restart
 ```
 
-#### Test 1 — the rules render a verdict (`wazuh-logtest`)
+---
 
-`wazuh-logtest` loads the ruleset from disk, so it confirms `whisper_rules.xml` maps a verdict to the
-right level without waiting for a live alert:
+## Integration Steps
 
-<details>
-<summary>Feed a decoded enrichment event per verdict and check the matched rule/level</summary>
+End to end, an enrichment flows like this:
+
+1. A rule fires and the alert lands in a group your `<integration>` filter watches (e.g. `sshd`).
+2. `integratord` invokes `custom-whisper` with the alert JSON.
+3. The connector extracts a **public IP or domain** from the alert (private / TEST-NET addresses are
+   skipped) and queries the Whisper graph — **no API key**.
+4. It derives an **evidence-based verdict** and writes a new alert under `data.whisper.*` back onto
+   the analysisd queue, linked to the triggering alert via `source_ref`.
+5. `whisper_rules.xml` renders the verdict as a Wazuh alert level, and the enrichment alert appears
+   in `wazuh-alerts-*`.
+
+The verdict → alert-level mapping (bundled rules):
+
+| Verdict | Meaning | Rule | Level |
+|---|---|---|---|
+| `known_bad` | confirmed-malicious evidence (C2 / malware / phishing) | 100201 | 12 |
+| `known_bad` (CRITICAL) | as above, with a critical graph score | 100205 | 14 |
+| `suspicious` | a threat signal without a confirmed-bad category (e.g. Tor / anonymizer) | 100202 | 7 |
+| `known_good` | allowlist-vouched, no threat | 100203 | 3 |
+| `unknown` | no data at this granularity (no-data ≠ safe) | 100204 | 3 |
+
+---
+
+## Integration Testing
+
+First enable the connector's debug log:
+
+```bash
+echo 'integrator.debug=2' >> /var/ossec/etc/local_internal_options.conf
+/var/ossec/bin/wazuh-control restart
+```
+
+**Test 1 — the rules render a verdict (`wazuh-logtest`).** `wazuh-logtest` loads the ruleset from
+disk, so it confirms `whisper_rules.xml` maps a verdict to the right level:
 
 ```bash
 # suspicious (a Tor exit) → rule 100202, level 7
-printf '%s\n' '{"integration":"custom-whisper","whisper":{"ioc":"185.220.101.1","verdict":"suspicious","level":"HIGH"}}' \
-  | sudo /var/ossec/bin/wazuh-logtest
+printf '%s\n' '{"integration":"custom-whisper","whisper":{"ioc":"185.220.101.1","verdict":"suspicious","level":"HIGH"}}' | /var/ossec/bin/wazuh-logtest
 #   Phase 3: id '100202'  level '7'  "Whisper: 185.220.101.1 is SUSPICIOUS (HIGH)"
 
-# known_good (an allowlisted resolver) → rule 100203, level 3
-printf '%s\n' '{"integration":"custom-whisper","whisper":{"ioc":"8.8.8.8","verdict":"known_good","level":"NONE"}}' \
-  | sudo /var/ossec/bin/wazuh-logtest
-#   Phase 3: id '100203'  level '3'
-
-# known_bad → rule 100201, level 12
-printf '%s\n' '{"integration":"custom-whisper","whisper":{"ioc":"1.2.3.4","verdict":"known_bad","level":"HIGH"}}' \
-  | sudo /var/ossec/bin/wazuh-logtest
-#   Phase 3: id '100201'  level '12'
+# known_good → rule 100203 (level 3);  known_bad → rule 100201 (level 12)
 ```
 
-</details>
-
-#### Test 2 — the connector enriches a live indicator (end to end)
-
-Run the connector against a single-alert JSON file (argv: `<alert-file> <api_key> <hook_url> debug`;
-the `api_key` is unused for the keyless graph and can be empty):
-
-<details>
-<summary>Enrich a real public IP and inspect the emitted <code>data.whisper.*</code> payload</summary>
+**Test 2 — the connector enriches a live indicator (end to end).** Run the connector against a
+single-alert JSON file (argv: `<alert-file> <api_key> <hook_url> debug`; `api_key` is unused for the
+keyless graph and can be empty):
 
 ```bash
 cat > /tmp/alert.json <<'JSON'
@@ -169,44 +186,33 @@ cat > /tmp/alert.json <<'JSON'
  "data":{"srcip":"185.220.101.1"},"location":"/var/log/auth.log"}
 JSON
 
-sudo /var/ossec/integrations/custom-whisper.py /tmp/alert.json '' '' debug
+/var/ossec/integrations/custom-whisper.py /tmp/alert.json '' '' debug
 #   whisper: invoke ioc=185.220.101.1 type=ipv4 ...
 #   whisper: api url=https://graph.whisper.security ms=...
 #   whisper: emit ... payload_bytes=...
 ```
 
-A new enrichment alert appears in **Discover → `wazuh-alerts-*`**; search `data.whisper.ioc:185.220.101.1`.
-A full captured walkthrough (the real graph response → the resulting `data.whisper.*` alert JSON) is
-in the upstream repo:
-[docs/scenarios/01-tor-ip-enrichment.md](https://github.com/whisper-sec/whisper-wazuh/blob/main/docs/scenarios/01-tor-ip-enrichment.md).
+**Check the results:**
 
-</details>
+* Connector diagnostics go to `/var/ossec/logs/integrations.log`; manager messages to
+  `/var/ossec/logs/ossec.log`; the decoded enrichment event is in
+  `/var/ossec/logs/archives/archives.log` when archiving is enabled.
+* In the **Wazuh dashboard** (Discover → `wazuh-alerts-*`), search `data.whisper.ioc:185.220.101.1`
+  — a new enrichment alert (e.g. rule 100202, *"Whisper: … is SUSPICIOUS (HIGH)"*) appears next to
+  the original.
 
-#### Test 3 — private / non-global IPs are skipped
+Private / non-global IPs are skipped by design — `grep whisper: /var/ossec/logs/integrations.log`
+shows `skip reason=non-global`, and no alert is produced.
 
-Private, loopback and TEST-NET addresses are never looked up (the public-IP guard). With debug on,
-`sudo grep whisper: /var/ossec/logs/integrations.log` shows `skip reason=non-global` — expected, no
-alert.
-
-## Beyond enrichment — the keyed tier
-
-The enrichment above is the keyless, always-on half. The upstream project adds a **keyed** tier for
-Whisper customers running agents on the platform:
-
-- **Agent-activity log source** (`whisper-logs`) — a scheduled poller that pulls your own agents'
-  activity (DNS allow/refused, egress connections, identity allocation) into Wazuh as
-  `data.whisper_agent.*` alerts. Enabled with `install.sh --logs`.
-- **On-demand CLI** (`whisper-investigate`) — runs deep Whisper investigation workflows on a single
-  indicator and prints a report.
-
-Both need a Whisper API key. See the upstream repo for install, packaging, and the full docs:
-**https://github.com/whisper-sec/whisper-wazuh**.
+---
 
 ## Sources
 
-- **Upstream project & full documentation:** <https://github.com/whisper-sec/whisper-wazuh>
-- **Adapted by:** Whisper Security
-- **Tested versions:** Wazuh **4.14.5**
-- **Maintainer:** Whisper Security (`security@whisper.security`)
-- **Support:** best-effort via the upstream repository's issues. API keys and tiers for the keyed
-  features: <https://www.whisper.security/pricing>
+* **Original source:** the upstream Whisper–Wazuh project, from which this integration is packaged —
+  <https://github.com/whisper-sec/whisper-wazuh> (full documentation, installers, and the keyed
+  agent-activity tier).
+* **Adapted by:** Whisper Security.
+* **Tested versions:** Wazuh **4.14.5**; the Whisper graph API (`graph.whisper.security`).
+* **Maintainer:** Whisper Security (`security@whisper.security`).
+* **Support boundary:** **Vendor-maintained**, best-effort via the upstream repository's issues;
+  provided as-is. API keys and tiers for the keyed features: <https://www.whisper.security/pricing>.

--- a/integrations/whisper/README.md
+++ b/integrations/whisper/README.md
@@ -1,0 +1,212 @@
+# Wazuh – Whisper Threat-Intelligence Enrichment Integration
+
+Enrich Wazuh alerts with relationship context from the [Whisper](https://www.whisper.security)
+infrastructure graph — the internet modeled as one connected graph (ASNs, prefixes, DNS, WHOIS,
+threat feeds, Tor relays, TLS fingerprints). When an alert carries a public IP or domain, this
+integration asks the graph what it knows and writes the answer back into Wazuh as a new,
+evidence-graded alert.
+
+> **This is the enrichment tier — it needs no API key** (the Whisper graph is queried anonymously).
+> Whisper also ships a *keyed* tier (an agent-activity log source) and an on-demand investigation
+> CLI, plus packaged installers (`.deb`/`.rpm`, a one-line bootstrap). Those live in the upstream
+> project — see [Beyond enrichment](#beyond-enrichment--the-keyed-tier) and
+> **https://github.com/whisper-sec/whisper-wazuh**.
+
+## Table of Contents
+
+- [Introduction](#introduction)
+- [Verdict → alert level](#verdict--alert-level)
+- [Installation and Configuration](#installation-and-configuration)
+- [Wazuh Configuration](#wazuh-configuration)
+  - [Integrator Config (manager `ossec.conf`)](#integrator-config-manager-ossecconf)
+  - [Custom Rules](#custom-rules)
+  - [Manual Tests](#manual-tests)
+- [Beyond enrichment — the keyed tier](#beyond-enrichment--the-keyed-tier)
+- [Sources](#sources)
+
+## Introduction
+
+This integration:
+
+- Extracts a **public IP or domain** from matching Wazuh alerts (flexible field-path detection across
+  `data.srcip`, Suricata/Cloudflare/GuardDuty/Security-Lake paths, etc.).
+- Queries the **Whisper graph** (`POST https://graph.whisper.security/api/query`) for an
+  evidence-based threat verdict — **no API key required** for these graph lookups.
+- Derives the **verdict from evidence** (threat-feed categories + confirmed-malicious node flags),
+  never copied from the raw score — *"trust never overrides threat."*
+- Writes back a new alert under `data.whisper.*`: verdict, risk score, level, threat feeds, tags,
+  ASN + reputation, prefix + registered-prefix threat, geo; for domains also DNS / WHOIS / SPF /
+  web-links / lookalike variants.
+- Links each enrichment to its triggering alert via `source_ref`, and de-duplicates repeat
+  indicators with a small SQLite cache (no re-lookup within a TTL).
+- Handles API / transport / auth errors gracefully, emitting typed error alerts rather than crashing.
+
+## Verdict → alert level
+
+The verdict is evidence-derived and mapped to a Wazuh alert level by the bundled rules
+(`whisper_rules.xml`):
+
+| Verdict | Meaning | Rule | Level |
+|---|---|---|---|
+| `known_bad` | confirmed-malicious evidence (C2 / malware / phishing feed or node flag) | 100201 | 12 |
+| `known_bad` (CRITICAL) | as above, with a critical graph score | 100205 | 14 |
+| `suspicious` | a threat signal without a confirmed-bad category (e.g. Tor / anonymizer / blocklist) | 100202 | 7 |
+| `known_good` | allowlist-vouched, no threat | 100203 | 3 |
+| `unknown` | no data at this granularity (no-data ≠ safe) | 100204 | 3 |
+
+Opt-in: rule **100206** flags a Cobalt-Strike TLS fingerprint (JARM) when the integration's
+`extra_enrichments` option includes `tls_fingerprint`.
+
+## Installation and Configuration
+
+The integration is **stdlib-only Python** on the manager's bundled interpreter — nothing to
+`pip install`. It ships five files:
+
+| File | Destination | Perms |
+|---|---|---|
+| `custom-whisper` (shell wrapper) | `/var/ossec/integrations/` | 750 `root:wazuh` |
+| `custom-whisper.py` (the connector) | `/var/ossec/integrations/` | 750 `root:wazuh` |
+| `whisper_client.py` (shared HTTP/TLS client — **imported** by the connector) | `/var/ossec/integrations/` | 640 `root:wazuh` |
+| `whisper_rules.xml` | `/var/ossec/etc/rules/` | 660 `root:wazuh` |
+| `whisper-template.json` (indexer field types) | PUT to the indexer | — |
+
+```bash
+# 1. scripts (the connector imports whisper_client.py, so all three go together)
+cp custom-whisper custom-whisper.py whisper_client.py /var/ossec/integrations/
+chown root:wazuh /var/ossec/integrations/custom-whisper /var/ossec/integrations/custom-whisper.py /var/ossec/integrations/whisper_client.py
+chmod 750 /var/ossec/integrations/custom-whisper /var/ossec/integrations/custom-whisper.py
+chmod 640 /var/ossec/integrations/whisper_client.py
+
+# 2. rules
+cp whisper_rules.xml /var/ossec/etc/rules/
+chown root:wazuh /var/ossec/etc/rules/whisper_rules.xml && chmod 660 /var/ossec/etc/rules/whisper_rules.xml
+
+# 3. indexer field types (analysisd stringifies every value; the template coerces
+#    data.whisper.* numbers/booleans back so range queries work)
+curl -sk -u <indexer-user>:<indexer-pass> -XPUT "https://<indexer>:9200/_template/whisper" \
+  -H 'Content-Type: application/json' -d @whisper-template.json
+```
+
+> The upstream project ships an `install.sh` that does all of the above with an `ossec.conf`
+> rollback and a post-restart verify, plus `.deb`/`.rpm` packages and a one-line bootstrap. If you
+> want the turnkey path, use it: <https://github.com/whisper-sec/whisper-wazuh#install>.
+
+## Wazuh Configuration
+
+### Integrator Config (manager `ossec.conf`)
+
+Add an `<integration>` block. There is **no `<api_key>`** — the graph enrichment is keyless. The
+`<name>` must match the shell wrapper.
+
+```xml
+<integration>
+  <name>custom-whisper</name>
+  <group>sshd</group>          <!-- the rule groups whose alerts get enriched -->
+  <alert_format>json</alert_format>
+</integration>
+```
+
+`<group>` (or `<rule_id>`) is your cost/noise dial: every matching alert that carries a public IP or
+domain becomes one graph lookup (deduped by the cache). Start narrow (e.g. `sshd`) and widen
+deliberately. **Never** point it at a group the enrichment alerts themselves carry — that would loop.
+
+Then restart the manager: `sudo /var/ossec/bin/wazuh-control restart`.
+
+### Custom Rules
+
+`whisper_rules.xml` renders the verdict as an alert level (see the table above). It installs to
+`/var/ossec/etc/rules/` and is picked up on the next manager restart. Without it, an enrichment is
+just a decoded event with no severity.
+
+### Manual Tests
+
+Turn on the connector's debug log first:
+
+```bash
+echo 'integrator.debug=2' | sudo tee -a /var/ossec/etc/local_internal_options.conf
+sudo /var/ossec/bin/wazuh-control restart
+```
+
+#### Test 1 — the rules render a verdict (`wazuh-logtest`)
+
+`wazuh-logtest` loads the ruleset from disk, so it confirms `whisper_rules.xml` maps a verdict to the
+right level without waiting for a live alert:
+
+<details>
+<summary>Feed a decoded enrichment event per verdict and check the matched rule/level</summary>
+
+```bash
+# suspicious (a Tor exit) → rule 100202, level 7
+printf '%s\n' '{"integration":"custom-whisper","whisper":{"ioc":"185.220.101.1","verdict":"suspicious","level":"HIGH"}}' \
+  | sudo /var/ossec/bin/wazuh-logtest
+#   Phase 3: id '100202'  level '7'  "Whisper: 185.220.101.1 is SUSPICIOUS (HIGH)"
+
+# known_good (an allowlisted resolver) → rule 100203, level 3
+printf '%s\n' '{"integration":"custom-whisper","whisper":{"ioc":"8.8.8.8","verdict":"known_good","level":"NONE"}}' \
+  | sudo /var/ossec/bin/wazuh-logtest
+#   Phase 3: id '100203'  level '3'
+
+# known_bad → rule 100201, level 12
+printf '%s\n' '{"integration":"custom-whisper","whisper":{"ioc":"1.2.3.4","verdict":"known_bad","level":"HIGH"}}' \
+  | sudo /var/ossec/bin/wazuh-logtest
+#   Phase 3: id '100201'  level '12'
+```
+
+</details>
+
+#### Test 2 — the connector enriches a live indicator (end to end)
+
+Run the connector against a single-alert JSON file (argv: `<alert-file> <api_key> <hook_url> debug`;
+the `api_key` is unused for the keyless graph and can be empty):
+
+<details>
+<summary>Enrich a real public IP and inspect the emitted <code>data.whisper.*</code> payload</summary>
+
+```bash
+cat > /tmp/alert.json <<'JSON'
+{"timestamp":"2026-01-01T00:00:00.000+0000","rule":{"id":"5710","level":5,"groups":["sshd"]},
+ "agent":{"id":"000","name":"manager"},"id":"1700000000.1","full_log":"...",
+ "data":{"srcip":"185.220.101.1"},"location":"/var/log/auth.log"}
+JSON
+
+sudo /var/ossec/integrations/custom-whisper.py /tmp/alert.json '' '' debug
+#   whisper: invoke ioc=185.220.101.1 type=ipv4 ...
+#   whisper: api url=https://graph.whisper.security ms=...
+#   whisper: emit ... payload_bytes=...
+```
+
+A new enrichment alert appears in **Discover → `wazuh-alerts-*`**; search `data.whisper.ioc:185.220.101.1`.
+A full captured walkthrough (the real graph response → the resulting `data.whisper.*` alert JSON) is
+in the upstream repo:
+[docs/scenarios/01-tor-ip-enrichment.md](https://github.com/whisper-sec/whisper-wazuh/blob/main/docs/scenarios/01-tor-ip-enrichment.md).
+
+</details>
+
+#### Test 3 — private / non-global IPs are skipped
+
+Private, loopback and TEST-NET addresses are never looked up (the public-IP guard). With debug on,
+`sudo grep whisper: /var/ossec/logs/integrations.log` shows `skip reason=non-global` — expected, no
+alert.
+
+## Beyond enrichment — the keyed tier
+
+The enrichment above is the keyless, always-on half. The upstream project adds a **keyed** tier for
+Whisper customers running agents on the platform:
+
+- **Agent-activity log source** (`whisper-logs`) — a scheduled poller that pulls your own agents'
+  activity (DNS allow/refused, egress connections, identity allocation) into Wazuh as
+  `data.whisper_agent.*` alerts. Enabled with `install.sh --logs`.
+- **On-demand CLI** (`whisper-investigate`) — runs deep Whisper investigation workflows on a single
+  indicator and prints a report.
+
+Both need a Whisper API key. See the upstream repo for install, packaging, and the full docs:
+**https://github.com/whisper-sec/whisper-wazuh**.
+
+## Sources
+
+- **Upstream project & full documentation:** <https://github.com/whisper-sec/whisper-wazuh>
+- **Adapted by:** Whisper Security
+- **Tested versions:** Wazuh **4.14.5**
+- **Maintainer:** Whisper Security (`security@whisper.security`)
+- **Support:** best-effort via the upstream repository's issues. API keys and tiers for the keyed
+  features: <https://www.whisper.security/pricing>

--- a/integrations/whisper/README.md
+++ b/integrations/whisper/README.md
@@ -222,6 +222,8 @@ shows `skip reason=non-global`, and no alert is produced.
   <https://github.com/whisper-sec/whisper-wazuh> (full documentation, installers, and the keyed
   agent-activity tier).
 * **Adapted by:** Whisper Security.
+* **Licence:** this copy is contributed under this repository's licence (AGPL-3.0), like every other
+  integration here. The upstream project is MIT-licensed.
 * **Tested versions:** Wazuh **4.14.5**; the Whisper graph API (`graph.whisper.online`).
 * **Maintainer:** Whisper Security (`security@whisper.security`).
 * **Support boundary:** **Vendor-maintained**, best-effort via the upstream repository's issues;

--- a/integrations/whisper/README.md
+++ b/integrations/whisper/README.md
@@ -43,7 +43,7 @@ interpreter — and the graph enrichment is **keyless** (no API key required).
 * **Wazuh Server (manager) 4.x** — tested on 4.14.5.
 * The manager's **bundled Python 3.10** — the connector is standard-library only; nothing to
   `pip install`.
-* **TLS egress** from the manager to `graph.whisper.security` (the graph API).
+* **TLS egress** from the manager to `graph.whisper.online` (the graph API).
 * The **Wazuh indexer reachable** from the manager, to install the field-type template.
 * **No API key** — the graph enrichment is queried anonymously. (The upstream *keyed* features need a
   Whisper API key; see [Sources](#sources).)
@@ -55,7 +55,7 @@ interpreter — and the graph enrichment is **keyless** (no API key required).
 ### Installing Whisper
 
 Nothing to install — Whisper is a hosted service. The connector queries the graph at
-`https://graph.whisper.security`; you only need TLS egress to it from the manager (see
+`https://graph.whisper.online`; you only need TLS egress to it from the manager (see
 [Prerequisites](#prerequisites)).
 
 ### Initial Whisper Configuration
@@ -122,6 +122,16 @@ curl -sk -u <indexer-user>:<indexer-pass> -XPUT "https://<indexer>:9200/_templat
 domain becomes one graph lookup (deduped by a small cache). Start narrow (e.g. `sshd`) and widen
 deliberately. Never point it at a group the enrichment alerts themselves carry.
 
+The callout is synchronous (integratord runs one alert at a time), so the connector keeps a
+wall-clock budget per invocation and never lets a slow or unreachable API stall the manager. Two
+optional `<options>` knobs tune it: `deadline` (seconds per alert, default `20`; every query's
+timeout and retry backoff shrink to what is left) and `max_iocs` (indicators enriched per alert,
+default `5`):
+
+```xml
+<options>{"deadline": 20, "max_iocs": 5}</options>
+```
+
 **5. Restart the manager** after these changes:
 
 ```bash
@@ -147,11 +157,11 @@ The verdict → alert-level mapping (bundled rules):
 
 | Verdict | Meaning | Rule | Level |
 |---|---|---|---|
-| `known_bad` | confirmed-malicious evidence (C2 / malware / phishing) | 100201 | 12 |
-| `known_bad` (CRITICAL) | as above, with a critical graph score | 100205 | 14 |
-| `suspicious` | a threat signal without a confirmed-bad category (e.g. Tor / anonymizer) | 100202 | 7 |
-| `known_good` | allowlist-vouched, no threat | 100203 | 3 |
-| `unknown` | no data at this granularity (no-data ≠ safe) | 100204 | 3 |
+| `known_bad` | confirmed-malicious evidence (C2 / malware / phishing) | 100501 | 12 |
+| `known_bad` (CRITICAL) | as above, with a critical graph score | 100505 | 14 |
+| `suspicious` | a threat signal without a confirmed-bad category (e.g. Tor / anonymizer) | 100502 | 7 |
+| `known_good` | allowlist-vouched, no threat | 100503 | 3 |
+| `unknown` | no data at this granularity (no-data ≠ safe) | 100504 | 3 |
 
 ---
 
@@ -168,11 +178,11 @@ echo 'integrator.debug=2' >> /var/ossec/etc/local_internal_options.conf
 disk, so it confirms `whisper_rules.xml` maps a verdict to the right level:
 
 ```bash
-# suspicious (a Tor exit) → rule 100202, level 7
+# suspicious (a Tor exit) → rule 100502, level 7
 printf '%s\n' '{"integration":"custom-whisper","whisper":{"ioc":"185.220.101.1","verdict":"suspicious","level":"HIGH"}}' | /var/ossec/bin/wazuh-logtest
-#   Phase 3: id '100202'  level '7'  "Whisper: 185.220.101.1 is SUSPICIOUS (HIGH)"
+#   Phase 3: id '100502'  level '7'  "Whisper: 185.220.101.1 is SUSPICIOUS (HIGH)"
 
-# known_good → rule 100203 (level 3);  known_bad → rule 100201 (level 12)
+# known_good → rule 100503 (level 3);  known_bad → rule 100501 (level 12)
 ```
 
 **Test 2 — the connector enriches a live indicator (end to end).** Run the connector against a
@@ -188,7 +198,7 @@ JSON
 
 /var/ossec/integrations/custom-whisper.py /tmp/alert.json '' '' debug
 #   whisper: invoke ioc=185.220.101.1 type=ipv4 ...
-#   whisper: api url=https://graph.whisper.security ms=...
+#   whisper: api url=https://graph.whisper.online ms=...
 #   whisper: emit ... payload_bytes=...
 ```
 
@@ -198,7 +208,7 @@ JSON
   `/var/ossec/logs/ossec.log`; the decoded enrichment event is in
   `/var/ossec/logs/archives/archives.log` when archiving is enabled.
 * In the **Wazuh dashboard** (Discover → `wazuh-alerts-*`), search `data.whisper.ioc:185.220.101.1`
-  — a new enrichment alert (e.g. rule 100202, *"Whisper: … is SUSPICIOUS (HIGH)"*) appears next to
+  — a new enrichment alert (e.g. rule 100502, *"Whisper: … is SUSPICIOUS (HIGH)"*) appears next to
   the original.
 
 Private / non-global IPs are skipped by design — `grep whisper: /var/ossec/logs/integrations.log`
@@ -212,7 +222,7 @@ shows `skip reason=non-global`, and no alert is produced.
   <https://github.com/whisper-sec/whisper-wazuh> (full documentation, installers, and the keyed
   agent-activity tier).
 * **Adapted by:** Whisper Security.
-* **Tested versions:** Wazuh **4.14.5**; the Whisper graph API (`graph.whisper.security`).
+* **Tested versions:** Wazuh **4.14.5**; the Whisper graph API (`graph.whisper.online`).
 * **Maintainer:** Whisper Security (`security@whisper.security`).
 * **Support boundary:** **Vendor-maintained**, best-effort via the upstream repository's issues;
   provided as-is. API keys and tiers for the keyed features: <https://www.whisper.security/pricing>.

--- a/integrations/whisper/custom-whisper
+++ b/integrations/whisper/custom-whisper
@@ -9,7 +9,7 @@
 # would otherwise exec an empty ${PYTHON_SCRIPT}, handing the alert tmp file to
 # Python as the program.
 #
-# Copyright (C) whisper.security — MIT
+# Copyright (C) whisper.security. Licensed under the terms in the repository's LICENSE file.
 
 WPYTHON_BIN="framework/python/bin/python3"
 

--- a/integrations/whisper/custom-whisper
+++ b/integrations/whisper/custom-whisper
@@ -9,7 +9,7 @@
 # would otherwise exec an empty ${PYTHON_SCRIPT}, handing the alert tmp file to
 # Python as the program.
 #
-# Copyright (C) whisper.security — Apache-2.0
+# Copyright (C) whisper.security — MIT
 
 WPYTHON_BIN="framework/python/bin/python3"
 

--- a/integrations/whisper/custom-whisper
+++ b/integrations/whisper/custom-whisper
@@ -1,0 +1,45 @@
+#!/bin/sh
+# custom-whisper — Whisper enrichment integration for Wazuh (Pattern A).
+# Wrapper modeled on the stock Wazuh integration launchers (virustotal): resolves the
+# manager's bundled Python and execs custom-whisper.py with integratord's argv intact.
+# Install target: /var/ossec/integrations/custom-whisper (750 root:wazuh).
+#
+# Unlike the stock wrapper, this one always pairs the .py next to itself and FAILS
+# LOUDLY when the interpreter or script is missing — the stock case-with-no-default
+# would otherwise exec an empty ${PYTHON_SCRIPT}, handing the alert tmp file to
+# Python as the program.
+#
+# Copyright (C) whisper.security — Apache-2.0
+
+WPYTHON_BIN="framework/python/bin/python3"
+
+SCRIPT_PATH_NAME="$0"
+
+DIR_NAME="$(cd "$(dirname "${SCRIPT_PATH_NAME}")" && pwd -P)"
+SCRIPT_NAME="$(basename "${SCRIPT_PATH_NAME}")"
+
+case ${DIR_NAME} in
+    */integrations)
+        # Installed layout: {WAZUH_HOME}/integrations/custom-whisper
+        WAZUH_PATH="${WAZUH_PATH:-$(cd "${DIR_NAME}/.." && pwd)}"
+    ;;
+    *)
+        # Any other location (e.g. the repo checkout) — default to the standard home.
+        WAZUH_PATH="${WAZUH_PATH:-/var/ossec}"
+    ;;
+esac
+
+PYTHON_BIN="${WAZUH_PATH}/${WPYTHON_BIN}"
+PYTHON_SCRIPT="${DIR_NAME}/${SCRIPT_NAME}.py"
+
+if [ ! -x "${PYTHON_BIN}" ]; then
+    echo "${SCRIPT_NAME}: wazuh python not found or not executable: ${PYTHON_BIN}" >&2
+    exit 1
+fi
+
+if [ ! -f "${PYTHON_SCRIPT}" ]; then
+    echo "${SCRIPT_NAME}: integration script not found: ${PYTHON_SCRIPT}" >&2
+    exit 1
+fi
+
+exec "${PYTHON_BIN}" "${PYTHON_SCRIPT}" "$@"

--- a/integrations/whisper/custom-whisper.py
+++ b/integrations/whisper/custom-whisper.py
@@ -22,6 +22,7 @@ the Whisper graph (#14) → inject a new alert onto the analysisd socket (#16) �
 import json
 import os
 import re
+import signal
 import socket
 import sqlite3
 import sys
@@ -35,15 +36,18 @@ from whisper_client import (
     DEFAULT_RETRIES,
     DEFAULT_TIMEOUT,
     WhisperAuthError,
+    WhisperDeadlineError,
     WhisperError,
     WhisperQueryError,
     WhisperTransportError,
     classify_domain,
-    execute_query,
     extract_url_host,
     parse_ip,
     resolve_api_key,
     resolve_api_url,
+)
+from whisper_client import (
+    execute_query as _client_execute_query,
 )
 
 # --- integratord argv contract (docs/whisper-to-wazuh-mapping.md §2.3) -----------------
@@ -82,6 +86,14 @@ MAX_EVENT_SIZE = 65535  # analysisd DGRAM datagram limit (matches maltiverse.py)
 # --- configuration defaults (resolution: <options> JSON → environment → default) --------
 # API_KEY_PLACEHOLDER / DEFAULT_API_URL / KEY_FILE imported from whisper_client.
 DEFAULT_DEDUP_TTL = 3600  # seconds — mapping §7.4
+# Wall-clock budget for ONE integratord invocation. integratord runs integrations serially, one
+# alert at a time, so a slow or blackholed API must cost seconds, not minutes: the deadline is
+# checked before every IOC and threaded into every query (timeouts + backoff shrink to what's
+# left). <options> "deadline" / WHISPER_DEADLINE, seconds.
+DEFAULT_DEADLINE = 20
+# The most IOCs enriched from a single alert (each is up to ~9 graph queries) — bounds the worst
+# case. <options> "max_iocs" / WHISPER_MAX_IOCS.
+DEFAULT_MAX_IOCS = 5
 DEFAULT_DEDUP_SCOPE = 'endpoint'  # 'endpoint' (key includes agent_id) | 'org' — mapping §7.2
 # Opt-in Tier-2 enrichments (#32). Each adds a query and/or has narrow, single-purpose
 # coverage, so all default OFF and are enabled individually via <options>.extra_enrichments.
@@ -163,6 +175,57 @@ class WhisperSocketError(WhisperError):
 debug_enabled = False
 
 
+# One wall-clock budget per invocation. integratord runs ONE alert per process, serially, so a
+# process-wide deadline is exact here: main() stamps it, and every graph query below reads it
+# through the execute_query wrapper, so retries and backoff can never overrun the budget the
+# manager is waiting on.
+_INVOCATION_DEADLINE: 'float | None' = None
+
+
+def execute_query(api_url, api_key, cypher, params=None, timeout=DEFAULT_TIMEOUT, retries=DEFAULT_RETRIES):
+    """whisper_client.execute_query bound to this invocation's deadline (_INVOCATION_DEADLINE).
+    Keeps the 6-positional contract every call site (and every test double) already uses."""
+    return _client_execute_query(
+        api_url, api_key, cypher, params, timeout, retries, deadline=_INVOCATION_DEADLINE
+    )
+
+
+# Hard ceiling. The per-query deadline bounds every request and every retry sleep, but a socket
+# timeout is per OPERATION: a server dripping one byte at a time, or a hung resolver, resets it and
+# can hold integratord well past the budget. A SIGALRM at the deadline (+1 s grace, so the precise
+# per-query path wins whenever it can) guarantees the bound whatever the socket does. integratord
+# runs the connector as a fresh main-thread process, which is exactly where an itimer is allowed;
+# anywhere else (no SIGALRM, not the main thread) the arm is a no-op and the per-query bound stands.
+def _hard_ceiling_handler(signum, frame):
+    raise WhisperDeadlineError(
+        'hard ceiling: wall-clock budget exhausted inside a stalled socket operation or resolver lookup'
+    )
+
+
+def _arm_hard_ceiling(seconds: float):
+    """SIGALRM `seconds` from now. Returns the previous handler for _disarm_hard_ceiling, or None
+    when a timer cannot be armed here."""
+    if not hasattr(signal, 'setitimer') or not hasattr(signal, 'SIGALRM'):
+        return None
+    try:
+        previous = signal.signal(signal.SIGALRM, _hard_ceiling_handler)
+        signal.setitimer(signal.ITIMER_REAL, max(0.001, seconds))
+        return previous
+    except (ValueError, OSError):  # not the main thread / itimers unavailable
+        return None
+
+
+def _disarm_hard_ceiling(previous) -> None:
+    if not hasattr(signal, 'setitimer') or not hasattr(signal, 'SIGALRM'):
+        return
+    try:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        if previous is not None:
+            signal.signal(signal.SIGALRM, previous)
+    except (ValueError, OSError):
+        pass
+
+
 def log_always(msg: str) -> None:
     """Unconditional log write (bad-argument errors are logged even with debug off)."""
     print(msg)
@@ -234,6 +297,36 @@ def resolve_dedup_ttl(options: dict, environ: dict) -> int:
         if ttl >= 0:
             return ttl
     return DEFAULT_DEDUP_TTL
+
+
+def resolve_deadline(options: dict, environ: dict) -> int:
+    """<options>.deadline → WHISPER_DEADLINE → default: the wall-clock budget (seconds) for one
+    integratord invocation. Same parsing rules as dedup_ttl; values below 1 fall through."""
+    for candidate in (options.get('deadline'), environ.get('WHISPER_DEADLINE')):
+        if candidate is None or isinstance(candidate, bool):
+            continue
+        try:
+            seconds = int(str(candidate).strip())
+        except ValueError:
+            continue
+        if seconds >= 1:
+            return seconds
+    return DEFAULT_DEADLINE
+
+
+def resolve_max_iocs(options: dict, environ: dict) -> int:
+    """<options>.max_iocs → WHISPER_MAX_IOCS → default: the most IOCs enriched from one alert
+    (each is up to ~9 graph queries, so this bounds the worst case). Values below 1 fall through."""
+    for candidate in (options.get('max_iocs'), environ.get('WHISPER_MAX_IOCS')):
+        if candidate is None or isinstance(candidate, bool):
+            continue
+        try:
+            n = int(str(candidate).strip())
+        except ValueError:
+            continue
+        if n >= 1:
+            return n
+    return DEFAULT_MAX_IOCS
 
 
 def resolve_dedup_scope(options: dict, environ: dict) -> bool:
@@ -1277,8 +1370,13 @@ def enrich(
                 else:
                     whisper.update(build_ip_fragments(cfg, ioc, ioc_type, flags, notes))
             except (WhisperTransportError, WhisperQueryError) as exc:
-                # Context fragments are best-effort — keep the verdict + threat_feed.
-                notes.append(f'context enrichment degraded ({exc.log_class})')
+                # Context fragments are best-effort — keep the verdict + threat_feed. Running out
+                # of the invocation's wall-clock budget here is the intended outage behaviour:
+                # the verdict is already in hand, the optional context is what gets dropped.
+                if isinstance(exc, WhisperDeadlineError):
+                    notes.append('context skipped (deadline)')
+                else:
+                    notes.append(f'context enrichment degraded ({exc.log_class})')
 
     if trunc:
         whisper['truncated'] = True
@@ -1486,42 +1584,73 @@ def main(args: 'list[str]') -> int:
     dedup_ttl = resolve_dedup_ttl(options, os.environ)
     include_agent = resolve_dedup_scope(options, os.environ)
     extra = resolve_extra_enrichments(options, os.environ)
+    budget = resolve_deadline(options, os.environ)
+    max_iocs = resolve_max_iocs(options, os.environ)
     api_key = resolve_api_key(args[APIKEY_INDEX] if len(args) > APIKEY_INDEX else '', os.environ)
     timeout = _argv_int(args, TIMEOUT_INDEX, DEFAULT_TIMEOUT)
     retries = _argv_int(args, RETRIES_INDEX, DEFAULT_RETRIES)
     agent_id = str(get_nested(alert, 'agent.id') or '000')
 
+    # One wall-clock budget for the whole invocation. integratord runs integrations serially, one
+    # alert at a time, so this is what keeps a slow or blackholed API from stalling the manager:
+    # stamped once here, read by every graph query (the execute_query wrapper), and checked again
+    # before each IOC so a budget already spent skips the rest in microseconds.
+    global _INVOCATION_DEADLINE
+    deadline = time.monotonic() + budget
+    _INVOCATION_DEADLINE = deadline
+    previous_handler = _arm_hard_ceiling(budget + 1.0)
+
     emitted = 0
     errors = 0
-    for ioc, ioc_type, field_path in candidates:
-        key = make_dedup_key(ioc_type, ioc, agent_id, include_agent)
-        log_invoke(ioc, ioc_type, key)
-        if check_dedup(key, dedup_ttl):
-            log_skip('dedup', dedup_key=key)
-            continue
-        try:
-            payload = enrich(
-                ioc,
-                ioc_type,
-                key,
-                build_source_ref(alert, field_path),
-                api_url,
-                api_key,
-                timeout,
-                retries,
-                extra,
-            )
-            sent = send_event(payload, alert.get('agent'))
-            record_dedup(key, dedup_ttl)  # only after a successful emit — failures stay retryable
-            log_emit(key, sent)
-            emitted += 1
-        except WhisperAuthError as exc:
-            # Terminal: the same key fails for every remaining candidate — stop the run.
-            log_error(exc)
-            return ERR_AUTH
-        except WhisperError as exc:
-            log_error(exc)
-            errors += 1
+    attempted = 0
+    try:
+        for ioc, ioc_type, field_path in candidates:
+            if time.monotonic() >= deadline:
+                log_skip('deadline', ioc=ioc)
+                errors += 1  # the run was cut short — an all-skipped run exits non-zero (TC-13)
+                continue
+            key = make_dedup_key(ioc_type, ioc, agent_id, include_agent)
+            log_invoke(ioc, ioc_type, key)
+            if check_dedup(key, dedup_ttl):
+                log_skip('dedup', dedup_key=key)
+                continue
+            # The cap bounds real enrichment WORK, not candidates: a dedup hit costs nothing and
+            # must not use up a slot that a later, still-unscored indicator needs.
+            attempted += 1
+            if attempted > max_iocs:
+                log_skip('max-iocs', ioc=ioc, limit=str(max_iocs))
+                continue
+            try:
+                payload = enrich(
+                    ioc,
+                    ioc_type,
+                    key,
+                    build_source_ref(alert, field_path),
+                    api_url,
+                    api_key,
+                    timeout,
+                    retries,
+                    extra,
+                )
+                sent = send_event(payload, alert.get('agent'))
+                record_dedup(key, dedup_ttl)  # only after a successful emit — failures stay retryable
+                log_emit(key, sent)
+                emitted += 1
+            except WhisperAuthError as exc:
+                # Terminal: the same key fails for every remaining candidate — stop the run.
+                log_error(exc)
+                return ERR_AUTH
+            except WhisperError as exc:
+                log_error(exc)
+                errors += 1
+    except WhisperDeadlineError as exc:
+        # The hard ceiling fired outside a query (a stalled dedup/socket step): the budget is gone,
+        # so stop the whole run rather than start anything else.
+        log_error(exc)
+        errors += 1
+    finally:
+        _disarm_hard_ceiling(previous_handler)
+        _INVOCATION_DEADLINE = None  # never leak this invocation's budget into a later caller
 
     # Exit 0 when anything landed (TC-15: a successful emit must not produce an
     # 'Exit status was:' line in ossec.log); non-zero only for all-failure runs (TC-13).

--- a/integrations/whisper/custom-whisper.py
+++ b/integrations/whisper/custom-whisper.py
@@ -1,0 +1,1532 @@
+#!/usr/bin/env python3
+"""custom-whisper — Whisper enrichment integration for Wazuh (Pattern A).
+
+Runs on the manager under wazuh-integratord. Extracts network IOCs (IPv4/IPv6/domain)
+from the triggering alert, enriches them from the Whisper infrastructure graph, and
+writes the result back as a new alert via the analysisd queue socket.
+
+Contracts implemented here (do not drift — the acceptance tests grep for them):
+  - argv:            docs/whisper-to-wazuh-mapping.md §2.3 (positional, never argc-based)
+  - log vocabulary:  docs/mvp-acceptance-criteria.md §3 (normative grep tokens)
+  - IOC extraction:  docs/whisper-to-wazuh-mapping.md §9 — table validated against the
+                     live 4.14.5 stack + ruleset source (issue #12 Q1, 2026-07-06)
+  - exit codes:      stock Wazuh integration numbering (virustotal.py) where meanings
+                     overlap: 2 bad args · 6 alert file not found · 7 invalid JSON
+
+Runtime: the manager's bundled Python (3.10) — stdlib only, no third-party imports.
+
+Pipeline (all stages implemented): extract IOCs (#13) → dedup check (#15) → enrich via
+the Whisper graph (#14) → inject a new alert onto the analysisd socket (#16) → record dedup.
+"""
+
+import json
+import os
+import re
+import socket
+import sqlite3
+import sys
+import time
+
+# Shared stdlib HTTP/TLS/auth client — the WAF-safe UA, CA-bundle resolution, retry taxonomy,
+# Whisper* exceptions, IOC primitives and config resolvers live here so the connector and the
+# analyst CLI (whisper-investigate) can never drift. Installed as a sibling in integrations/.
+import whisper_client
+from whisper_client import (
+    DEFAULT_RETRIES,
+    DEFAULT_TIMEOUT,
+    WhisperAuthError,
+    WhisperError,
+    WhisperQueryError,
+    WhisperTransportError,
+    classify_domain,
+    execute_query,
+    extract_url_host,
+    parse_ip,
+    resolve_api_key,
+    resolve_api_url,
+)
+
+# --- integratord argv contract (docs/whisper-to-wazuh-mapping.md §2.3) -----------------
+# argv[1] alert tmp file · argv[2] api_key · argv[3] hook_url (ignored, never validated;
+# deliberately no constant — this integration never reads it) · argv[4] 'debug'/'' ·
+# argv[5] options tmp file/'' · argv[6] timeout · argv[7] retries
+# (+ a literal trailing "> /dev/null 2>&1" argument when debug is off — read positionally)
+ALERT_INDEX = 1
+APIKEY_INDEX = 2
+DEBUG_INDEX = 4
+OPTIONS_INDEX = 5
+TIMEOUT_INDEX = 6
+RETRIES_INDEX = 7
+
+# DEFAULT_TIMEOUT / DEFAULT_RETRIES imported from whisper_client.
+
+# Exit codes. 2/6/7 mirror the stock convention exactly (virustotal.py: ERR_BAD_ARGUMENTS,
+# ERR_FILE_NOT_FOUND, ERR_INVALID_JSON); 5 is reserved to match ERR_SOCKET_OPERATION for
+# #16. 8/10 are whisper-specific and picked from unclaimed numbers.
+ERR_BAD_ARGUMENTS = 2
+ERR_SOCKET_OPERATION = 5  # reserved — #16
+ERR_FILE_NOT_FOUND = 6
+ERR_INVALID_JSON = 7
+ERR_AUTH = 8  # terminal auth failure (TC-12)
+
+INTEGRATION_NAME = 'custom-whisper'
+
+# Wazuh home is one level up from integrations/. realpath (not abspath) so a symlinked
+# install still resolves inside /var/ossec — mirrors the stock virustotal.py idiom.
+pwd = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+LOG_FILE = f'{pwd}/logs/integrations.log'
+SOCKET_ADDR = f'{pwd}/queue/sockets/queue'
+DEDUP_DB = f'{pwd}/var/whisper/dedup.db'  # normative path — mapping §7.5
+MAX_EVENT_SIZE = 65535  # analysisd DGRAM datagram limit (matches maltiverse.py); errno 90 above it
+
+# --- configuration defaults (resolution: <options> JSON → environment → default) --------
+# API_KEY_PLACEHOLDER / DEFAULT_API_URL / KEY_FILE imported from whisper_client.
+DEFAULT_DEDUP_TTL = 3600  # seconds — mapping §7.4
+DEFAULT_DEDUP_SCOPE = 'endpoint'  # 'endpoint' (key includes agent_id) | 'org' — mapping §7.2
+# Opt-in Tier-2 enrichments (#32). Each adds a query and/or has narrow, single-purpose
+# coverage, so all default OFF and are enabled individually via <options>.extra_enrichments.
+# tls_fingerprint: (ip)-[:EMITS_TLS_FINGERPRINT]->(:TLS_FINGERPRINT) — a Cobalt-Strike-default
+# JARM emitted only when present (a frozen, sparse catalog; absence is never rendered).
+KNOWN_EXTRA_ENRICHMENTS = frozenset({'tls_fingerprint'})
+
+# --- IOC extraction table (mapping §9, validated by issue #12 Q1 on 2026-07-06) ---------
+# One table, one row per path: (full dotted path from the alert root, hint, status).
+# hint drives the normalizer dispatch; status 'inactive' rows are documented-but-not-
+# extracted and emit the normative unsupported-type line (TC-22). Order = emission order.
+# Evidence classes from Q1: live-observed on the dev stack, template-mapped in
+# wazuh-template.json, or ruleset-referenced in the 4.14.5 rules/decoders.
+ACTIVE = 'active'
+INACTIVE = 'inactive'
+FIELD_PATHS: 'tuple[tuple[str, str, str], ...]' = (
+    # Generic network decoders (srcip live-observed: sshd 5710/5715, nginx 31101)
+    ('data.srcip', 'ip', ACTIVE),
+    ('data.dstip', 'ip', ACTIVE),
+    ('data.audit.srcip', 'ip', ACTIVE),
+    # Appliance decoders — Cisco FTD/ASA, Sophos FW (ruleset-referenced)
+    ('data.src_ip', 'ip', ACTIVE),
+    ('data.dst_ip', 'ip', ACTIVE),
+    # Suricata eve — NB dest_ip, not dst_ip (0999 rules 99915-99918)
+    ('data.dest_ip', 'ip', ACTIVE),
+    ('data.http.hostname', 'domain', ACTIVE),
+    ('data.dns.rrname', 'domain', ACTIVE),
+    # Windows / Sysmon — casing verified against 0810/0840/0590 rules
+    ('data.win.eventdata.ipAddress', 'ip', ACTIVE),
+    ('data.win.eventdata.sourceIp', 'ip', ACTIVE),
+    ('data.win.eventdata.destinationIp', 'ip', ACTIVE),
+    ('data.win.eventdata.queryName', 'domain', ACTIVE),
+    ('data.win.eventdata.destinationHostname', 'domain', ACTIVE),
+    # AWS — CloudTrail camelCase AND Macie snake_case both exist; VPC flow; WAF;
+    # GuardDuty network/port-probe findings; Security Lake
+    ('data.aws.sourceIPAddress', 'ip', ACTIVE),
+    ('data.aws.source_ip_address', 'ip', ACTIVE),
+    ('data.aws.srcaddr', 'ip', ACTIVE),
+    ('data.aws.dstaddr', 'ip', ACTIVE),
+    ('data.aws.httpRequest.clientIp', 'ip', ACTIVE),
+    ('data.aws.service.action.networkConnectionAction.remoteIpDetails.ipAddressV4', 'ip', ACTIVE),
+    ('data.aws.service.action.portProbeAction.portProbeDetails.remoteIpDetails.ipAddressV4', 'ip', ACTIVE),
+    ('data.src_endpoint.ip', 'ip', ACTIVE),
+    # GCP
+    ('data.gcp.jsonPayload.sourceIP', 'ip', ACTIVE),
+    ('data.gcp.jsonPayload.queryName', 'domain', ACTIVE),
+    # Office 365 / MS Graph — ClientIP frequently carries ip:port (normalizer strips it)
+    ('data.office365.ClientIP', 'ip', ACTIVE),
+    ('data.ms-graph.actor.ipAddress', 'ip', ACTIVE),
+    # Cloudflare WAF (0935 + 0999 rule 99902)
+    ('data.ClientIP', 'ip', ACTIVE),
+    ('data.OriginIP', 'ip', ACTIVE),
+    # macOS screen sharing (0999 rules 99909/99910)
+    ('data.ip_address', 'ip', ACTIVE),
+    # Web access logs: host component of ABSOLUTE URLs only — nginx/apache values are
+    # path-only (Q1 live evidence); squid-style absolute URLs carry a host
+    ('data.url', 'url_host', ACTIVE),
+    # Documented-but-inactive (mapping §9: hash/path triggers out of MVP scope) — TC-22
+    ('syscheck.sha256_after', 'hash', INACTIVE),
+    ('syscheck.path', 'path', INACTIVE),
+    # NOTE agent.ip is deliberately NOT a trigger (present on every agent alert; the
+    # alert is not about the agent's own address). Resolved with #12 Q1.
+)
+
+MAX_LIST_VALUES = 10  # bound list-valued fields (some JSON decoders aggregate repeats)
+ORIGINAL_LOG_MAX = 512  # source_ref.original_full_log truncation — mapping §4.2
+
+
+# _DOMAIN_RE and the WhisperError / Auth / Transport / Query taxonomy are imported from
+# whisper_client. WhisperSocketError is analysisd-only (the socket write-back, #16), so it
+# lives here and subclasses the imported base.
+class WhisperSocketError(WhisperError):
+    """analysisd socket failures (errno 90 oversize, connect refused) — for #16."""
+
+    log_class = 'socket'
+
+
+# --- logging (virustotal.py convention + the normative vocabulary) ----------------------
+debug_enabled = False
+
+
+def log_always(msg: str) -> None:
+    """Unconditional log write (bad-argument errors are logged even with debug off)."""
+    print(msg)
+    try:
+        with open(LOG_FILE, 'a') as f:
+            f.write(msg + '\n')
+    except OSError:
+        pass  # never let logging kill the run
+
+
+def debug(msg: str) -> None:
+    if debug_enabled:
+        log_always(msg)
+
+
+# Normative vocabulary — docs/mvp-acceptance-criteria.md §3. Exact prefixes; tests assert.
+def log_invoke(ioc: str, ioc_type: str, key: str) -> None:
+    debug(f'whisper: invoke ioc={ioc} type={ioc_type} dedup_key={key}')
+
+
+def log_skip(reason: str, **kv: str) -> None:
+    extra = ''.join(f' {k}={v}' for k, v in kv.items())
+    debug(f'whisper: skip reason={reason}{extra}')
+
+
+def log_api(url: str, ms: int) -> None:
+    debug(f'whisper: api url={url} ms={ms}')
+
+
+# Route execute_query's per-call timing (emitted from whisper_client) through this connector's
+# debug log — gated by debug_enabled, so silent unless integratord passes 'debug'.
+whisper_client.log_api = log_api
+
+
+def log_error(exc: WhisperError) -> None:
+    debug(f'whisper: error class={exc.log_class} detail={exc}')
+
+
+def log_emit(key: str, payload_bytes: int) -> None:
+    debug(f'whisper: emit dedup_key={key} payload_bytes={payload_bytes}')
+
+
+# --- configuration resolution ------------------------------------------------------------
+def load_options(path: str) -> dict:
+    """Read the <options> JSON tmp file (argv[5]); empty/missing/invalid → {}."""
+    if not path:
+        return {}
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def resolve_dedup_ttl(options: dict, environ: dict) -> int:
+    """<options>.dedup_ttl → WHISPER_DEDUP_TTL → default.
+
+    Non-numeric, negative, and JSON booleans all fall through — int(True) == 1 would
+    otherwise turn a well-meant `"dedup_ttl": true` into a 1-second TTL.
+    """
+    for candidate in (options.get('dedup_ttl'), environ.get('WHISPER_DEDUP_TTL')):
+        if candidate is None or isinstance(candidate, bool):
+            continue
+        try:
+            ttl = int(str(candidate).strip())
+        except ValueError:
+            continue
+        if ttl >= 0:
+            return ttl
+    return DEFAULT_DEDUP_TTL
+
+
+def resolve_dedup_scope(options: dict, environ: dict) -> bool:
+    """True = per-endpoint dedup (key includes agent_id); False = org-wide (mapping §7.2).
+
+    <options>.dedup_scope → WHISPER_DEDUP_SCOPE → default 'endpoint'.
+    """
+    for candidate in (options.get('dedup_scope'), environ.get('WHISPER_DEDUP_SCOPE')):
+        if isinstance(candidate, str):
+            scope = candidate.strip().lower()
+            if scope == 'org':
+                return False
+            if scope == 'endpoint':
+                return True
+    return DEFAULT_DEDUP_SCOPE == 'endpoint'
+
+
+def resolve_extra_enrichments(options: dict, environ: dict) -> 'frozenset[str]':
+    """The opt-in Tier-2 enrichments to run, intersected with KNOWN_EXTRA_ENRICHMENTS (#32).
+
+    <options>.extra_enrichments (JSON list, or comma string) → WHISPER_EXTRA_ENRICHMENTS
+    (comma-separated) → default none. Unknown names are ignored — a typo silently disables
+    the feature, never errors the run.
+
+    A PRESENT `extra_enrichments` key is authoritative regardless of shape: a valid list/string
+    is parsed, a malformed value (dict/int/bool) means "no extras" — it must NOT silently fall
+    through to the env var (that would let a config typo be overridden by a stale environment).
+    Only an ABSENT key falls through to the environment.
+    """
+    if 'extra_enrichments' in options:
+        raw = options['extra_enrichments']
+        if isinstance(raw, (list, tuple)):
+            names = [str(x) for x in raw]
+        elif isinstance(raw, str):
+            names = raw.split(',')
+        else:
+            names = []  # present but malformed → no extras (do not defer to env)
+    else:
+        names = environ.get('WHISPER_EXTRA_ENRICHMENTS', '').split(',')
+    return frozenset(n.strip() for n in names if n.strip()) & KNOWN_EXTRA_ENRICHMENTS
+
+
+def _argv_int(args: 'list[str]', idx: int, default: int) -> int:
+    """Lenient positive-int parse for integratord's timeout/retries argv slots."""
+    if len(args) > idx:
+        try:
+            n = int(args[idx])
+        except (TypeError, ValueError):
+            return default
+        if n > 0:
+            return n
+    return default
+
+
+# --- alert handling ----------------------------------------------------------------------
+def load_alert(path: str) -> dict:
+    """Read the single-alert JSON tmp file integratord hands us (argv[1])."""
+    with open(path) as f:
+        return json.load(f)
+
+
+def get_nested(obj: dict, dotted: str):
+    """Resolve a dotted path against the alert JSON; None when any hop is missing."""
+    cur = obj
+    for part in dotted.split('.'):
+        if not isinstance(cur, dict) or part not in cur:
+            return None
+        cur = cur[part]
+    return cur
+
+
+def is_self_alert(alert: dict) -> bool:
+    """Feedback-loop guard #3: never process our own enrichment alerts (mapping §8)."""
+    return get_nested(alert, 'data.integration') == INTEGRATION_NAME
+
+
+# _strip_port / parse_ip / classify_domain / extract_url_host imported from whisper_client.
+def _classify(value: str, hint: str) -> 'tuple[str | None, str | None, str | None]':
+    """Classify one raw string value per its path hint.
+
+    Returns a tagged tuple — plain data flow, no exceptions as control flow:
+      ('ok', ioc, ioc_type)        — a global IP or plausible domain
+      ('non-global', display, None) — an IP the public-IP guard rejects
+      (None, None, None)            — not an IOC of this hint's kind
+    """
+    v = value.strip()
+    if hint == 'url_host':
+        host = extract_url_host(v)
+        if host is None:
+            return (None, None, None)
+        v = host  # the host may itself be an IP or a domain — fall through
+    ip = parse_ip(v)
+    if ip is not None:
+        if not ip.is_global:
+            return ('non-global', v, None)
+        return ('ok', str(ip), 'ipv4' if ip.version == 4 else 'ipv6')
+    if hint in ('domain', 'url_host'):
+        domain = classify_domain(v)
+        if domain is not None:
+            return ('ok', domain, 'domain')
+    return (None, None, None)
+
+
+def extract_iocs(alert: dict) -> 'list[tuple[str, str, str]]':
+    """Walk FIELD_PATHS and return [(ioc, type, field_path), ...], deduplicated.
+
+    Emits the normative guard lines (acceptance §3):
+      skip reason=non-global        — public-IP guard (TC-04/05)
+      skip reason=unsupported-type  — inactive hash/path rows (TC-22)
+      skip reason=no-ioc            — NO supported path had any value at all (TC-21);
+                                      a path holding a non-IOC value is 'present' and
+                                      therefore never a no-ioc case (it gets a debug line)
+    """
+    candidates: list[tuple[str, str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    any_present = False
+
+    for path, hint, status in FIELD_PATHS:
+        value = get_nested(alert, path)
+        if value is None or value == '' or value == []:
+            continue
+        any_present = True  # presence is about the PATH, not the value's type/validity
+
+        if status == INACTIVE:
+            log_skip('unsupported-type', field=path)
+            continue
+
+        values = value if isinstance(value, list) else [value]
+        for raw in values[:MAX_LIST_VALUES]:
+            if not isinstance(raw, str) or not raw.strip():
+                debug(f'whisper: ignoring non-string value at {path}')
+                continue
+            kind, ioc, ioc_type = _classify(raw, hint)
+            if kind == 'non-global':
+                log_skip('non-global', ioc=ioc)
+            elif kind == 'ok':
+                if (ioc, ioc_type) not in seen:
+                    seen.add((ioc, ioc_type))
+                    candidates.append((ioc, ioc_type, path))
+            else:
+                debug(f'whisper: ignoring value at {path} (not a valid {hint})')
+
+    if not any_present:
+        log_skip('no-ioc')
+    return candidates
+
+
+def make_dedup_key(ioc_type: str, ioc: str, agent_id: str, include_agent: bool = True) -> str:
+    """`{type}|{ioc}|{agent_id}` — agent segment gated by dedup_scope (mapping §7.2)."""
+    if include_agent:
+        return f'{ioc_type}|{ioc}|{agent_id}'
+    return f'{ioc_type}|{ioc}'
+
+
+def build_source_ref(alert: dict, field_path: str) -> dict:
+    """The mapping-§4.2 source_ref linkage block for one extracted IOC."""
+    return {
+        'rule_id': str(get_nested(alert, 'rule.id') or ''),
+        'alert_id': str(alert.get('id') or ''),
+        'agent_id': str(get_nested(alert, 'agent.id') or '000'),
+        'field_path': field_path,
+        'original_full_log': str(alert.get('full_log') or '')[:ORIGINAL_LOG_MAX],
+    }
+
+
+# ==========================================================================================
+# #14 — Whisper client, enrichment builders & verdict derivation
+# ==========================================================================================
+
+
+# --- explain() — the authoritative threat verdict (mapping §5/§6) -------------------------
+# The procedure is multi-shape: the rich shape below on success, and a degraded shape
+# carrying error/retryAfter when the scoring backend is down. NOTE the REST layer has no
+# `coverage` field (that is an MCP-surface addition) — coverage.granularity is derived
+# from the IOC type; shared_host/data_coverage stay None and are stripped before send.
+_EXPLAIN_FIELDS = (
+    'indicator, type, available, cached, found, score, level, '
+    'explanation, factors, sources, breakdown, advisory'
+)
+_EXPLAIN_ERROR_FIELDS = 'indicator, type, available, error, retryAfter, advisory'
+
+
+def call_explain(cfg: dict, ioc: str) -> dict:
+    """One explain() row for the IOC; {'available': False, ...} when the backend is degraded."""
+    rich = f'CALL explain($ioc) YIELD {_EXPLAIN_FIELDS} RETURN {_EXPLAIN_FIELDS} LIMIT 1'
+    try:
+        rows = execute_query(
+            cfg['api_url'], cfg['api_key'], rich, {'ioc': ioc}, cfg['timeout'], cfg['retries']
+        )
+    except WhisperQueryError as rich_err:
+        # A query error on the rich shape is usually the degraded backend answering with the
+        # error-shaped YIELD — retry that shape to harvest retryAfter. But a genuine 400 (bad
+        # YIELD, proxy HTML) fails BOTH shapes; surface the ORIGINAL error, not the fallback's.
+        debug(f'whisper: explain rich-shape failed, trying degraded shape ({rich_err})')
+        fallback = f'CALL explain($ioc) YIELD {_EXPLAIN_ERROR_FIELDS} RETURN {_EXPLAIN_ERROR_FIELDS} LIMIT 1'
+        try:
+            rows = execute_query(
+                cfg['api_url'], cfg['api_key'], fallback, {'ioc': ioc}, cfg['timeout'], cfg['retries']
+            )
+        except WhisperQueryError:
+            raise rich_err from None
+    return rows[0] if rows else {'available': False, 'found': False}
+
+
+# --- feed polarity (issue #12 Q5) ---------------------------------------------------------
+# Static slug→category map generated from the live graph (FEED_SOURCE.id → CATEGORY.name,
+# 43 feeds, 2026-07-06). "Listed in N feeds" is never itself bad — polarity comes from the
+# category (mapping §6). The feed set evolves (per-variant slugs like hagezi-dns-pro-ip),
+# so unknown slugs fall through to prefix matching, then to None (neutral).
+FEED_CATEGORIES = {
+    'tranco-top1m': 'Popularity/Trust',
+    'cloudflare-radar-top1m': 'Popularity/Trust',
+    'abuse-ch-feodo-tracker': 'C2 Servers',
+    'abuse-ch-threatfox-iocs': 'C2 Servers',
+    'botvrij-ioc-dst-ip': 'C2 Servers',
+    'c2intelfeeds': 'C2 Servers',
+    'abuse-ch-urlhaus': 'Malware Distribution',
+    'abuse-ch-malwarebazaar': 'Malware Distribution',
+    'openphish': 'Phishing',
+    'blocklist-de-ssh': 'Brute Force',
+    'dataplane-sshpwauth': 'Brute Force',
+    'dataplane-sshclient': 'Brute Force',
+    'bruteforceblocker': 'Brute Force',
+    'cert-pl-domains': 'Malicious Domains',
+    'botvrij-ioc-domain': 'Malicious Domains',
+    'ofac-sdn-crypto-eth': 'OFAC SDN Sanctions',
+    'ofac-sdn-crypto-btc': 'OFAC SDN Sanctions',
+    'ofac-sdn-crypto-trx': 'OFAC SDN Sanctions',
+    'ofac-sdn-crypto-sol': 'OFAC SDN Sanctions',
+    'tor-exit-nodes': 'TOR Network',
+    'dan-tor-exit': 'TOR Network',
+    'firehol-anonymous': 'Proxies',
+    'spamhaus-drop': 'General Blacklists',
+    'spamhaus-edrop': 'General Blacklists',
+    'firehol-level1': 'General Blacklists',
+    'firehol-level2': 'General Blacklists',
+    'firehol-level3': 'General Blacklists',
+    'stamparm-ipsum': 'General Blacklists',
+    'greensnow': 'General Blacklists',
+    'blocklist-de-all': 'General Blacklists',
+    'cins-score': 'General Blacklists',
+    'binarydefense-banlist': 'General Blacklists',
+    'emerging-threats-compromised': 'General Blacklists',
+    'interserver-level1': 'General Blacklists',
+    'firehol-abusers-1d': 'General Blacklists',
+    'firehol-webclient': 'General Blacklists',
+    'dataplane-dnsrd': 'General Blacklists',
+    'abuse-ch-ssl-blacklist': 'General Blacklists',
+    'blocklist-de-mail': 'Spam',
+    'alienvault-reputation': 'Reputation',
+    'stevenblack-hosts': 'Ad/Tracking Blocklists',
+    'hagezi-dns-light': 'Ad/Tracking Blocklists',
+    'hagezi-dns-pro': 'Ad/Tracking Blocklists',
+}
+FEED_CATEGORY_PREFIXES = (
+    ('hagezi-', 'Ad/Tracking Blocklists'),
+    ('oisd-', 'Ad/Tracking Blocklists'),
+    ('stevenblack-', 'Ad/Tracking Blocklists'),
+    ('stopforumspam-', 'Spam'),
+    ('firehol-', 'General Blacklists'),
+    ('blocklist-de-', 'General Blacklists'),
+    ('ofac-sdn-', 'OFAC SDN Sanctions'),
+    ('phishtank', 'Phishing'),
+    ('tor-', 'TOR Network'),
+)
+TRUST_CATEGORIES = frozenset({'Popularity/Trust'})
+CONFIRMED_BAD_CATEGORIES = frozenset(
+    {
+        'C2 Servers',
+        'Malware Distribution',
+        'Phishing',
+        'Brute Force',
+        'Attack Sources',
+        'Exfiltration Destinations',
+        'Malicious Domains',
+        'Malicious Infrastructure',
+        'State Actor & Sanctions',
+        'OFAC SDN Sanctions',
+    }
+)
+# Real-but-not-confirmed-malicious threat signals → suspicious (never known_good, never
+# known_bad on their own). Ad/Tracking Blocklists are DNS-filter noise and Reputation is
+# a weak aggregate; both are treated as neutral (not enough for suspicious by themselves).
+SUSPICIOUS_CATEGORIES = CONFIRMED_BAD_CATEGORIES | frozenset(
+    {
+        'General Blacklists',
+        'Spam',
+        'TOR Network',
+        'Proxies',
+        'Anonymization Infrastructure',
+        'VPNs',
+    }
+)
+
+
+def feed_category(slug: str) -> 'str | None':
+    if slug in FEED_CATEGORIES:
+        return FEED_CATEGORIES[slug]
+    for prefix, category in FEED_CATEGORY_PREFIXES:
+        if slug.startswith(prefix):
+            return category
+    return None
+
+
+# --- node threat flags ---------------------------------------------------------------------
+THREAT_FLAGS = (
+    'isThreat',
+    'isC2',
+    'isMalware',
+    'isPhishing',
+    'isBotnet',
+    'isBruteforce',
+    'isScanner',
+    'isSpam',
+    'isBlacklist',
+    'isDga',
+    'isExfilDestination',
+    'isOfacSanctioned',
+    'isStateActor',
+    'isTor',
+    'isProxy',
+    'isVpn',
+    'isAnonymizer',
+    'isReputation',
+    'isWhitelist',
+)
+# Flags that count as threat evidence for the verdict (Tor/proxy/VPN/anonymizer are
+# context, not maliciousness — mapping §6's Tor example).
+BAD_FLAGS = frozenset(
+    {
+        'isThreat',
+        'isC2',
+        'isMalware',
+        'isPhishing',
+        'isBotnet',
+        'isBruteforce',
+        'isScanner',
+        'isSpam',
+        'isBlacklist',
+        'isDga',
+        'isExfilDestination',
+        'isOfacSanctioned',
+        'isStateActor',
+    }
+)
+# Flags that are confirmed-malicious on their OWN (#30) — the node IS bad infrastructure,
+# so the verdict is known_bad regardless of feed category or severity level. Distinct from
+# BAD_FLAGS: the generic/aggregate (isThreat), the annoyance (isBruteforce/isScanner), the
+# heuristic (isDga), and the merely-listed (isSpam/isBlacklist) stay suspicious-level evidence,
+# not known_bad. isOfacSanctioned = legally designated; isStateActor = nation-state attribution.
+HARD_BAD_FLAGS = frozenset(
+    {
+        'isC2',
+        'isMalware',
+        'isPhishing',
+        'isBotnet',
+        'isExfilDestination',
+        'isOfacSanctioned',
+        'isStateActor',
+    }
+)
+TAG_BY_FLAG = {
+    'isThreat': 'threat',
+    'isC2': 'c2',
+    'isMalware': 'malware',
+    'isPhishing': 'phishing',
+    'isBotnet': 'botnet',
+    'isBruteforce': 'bruteforce',
+    'isScanner': 'scanner',
+    'isSpam': 'spam',
+    'isBlacklist': 'blacklist',
+    'isDga': 'dga',
+    'isExfilDestination': 'exfil',
+    'isOfacSanctioned': 'ofac-sanctioned',
+    'isStateActor': 'state-actor',
+    'isTor': 'tor',
+    'isProxy': 'proxy',
+    'isVpn': 'vpn',
+    'isAnonymizer': 'anonymizer',
+}
+_NODE_LABELS = {'ipv4': 'IPV4', 'ipv6': 'IPV6', 'domain': 'HOSTNAME'}
+
+
+def fetch_flags(cfg: dict, ioc: str, ioc_type: str) -> 'dict | None':
+    """The node's is* boolean threat flags, or None when the node is ABSENT.
+
+    This is also the authoritative `known` signal: `explain().found` is unreliable for
+    domains (it returns true for any well-formed name even with no node — verified
+    2026-07-06), so node existence is determined here, by an anchored MATCH.
+    """
+    label = _NODE_LABELS[ioc_type]
+    projection = ', '.join(f'n.{f} AS {f}' for f in THREAT_FLAGS)
+    rows = execute_query(
+        cfg['api_url'],
+        cfg['api_key'],
+        f'MATCH (n:{label} {{name: $v}}) RETURN {projection} LIMIT 1',
+        {'v': ioc},
+        cfg['timeout'],
+        cfg['retries'],
+    )
+    return rows[0] if rows else None
+
+
+# --- verdict derivation (mapping §6 — ordered gates, first match wins) ---------------------
+def derive_verdict(explain_row: dict, flags: dict, known: bool = True) -> str:
+    """Evidence-derived verdict. The Whisper score is evidence, never the answer:
+    verdict comes from the level enum + feed *category* polarity + node flags —
+    never from the raw score and never from the explanation string (they can disagree).
+
+    `known` = the IOC has a real graph node (from fetch_flags, NOT explain().found, which
+    is unreliable for domains). NOTE the §6 coverage gate (shared_host / data_coverage →
+    unknown) is NOT enforced here: the REST explain() surface exposes no coverage block
+    (verified 2026-07-06). The gate order is otherwise conservative — any confirmed-bad or
+    threat signal blocks known_good — so a multi-tenant apex listed only in trust feeds is
+    the one residual case (documented in mapping §6/§11).
+    """
+    level = explain_row.get('level') or 'NONE'
+    sources = explain_row.get('sources') or []
+    categories = [feed_category(str(s.get('feedId', ''))) for s in sources]
+    has_confirmed_bad = any(c in CONFIRMED_BAD_CATEGORIES for c in categories)
+    has_suspicious_cat = any(c in SUSPICIOUS_CATEGORIES for c in categories)
+    has_bad_flags = any(flags.get(f) for f in BAD_FLAGS)
+    has_hard_bad_flag = any(flags.get(f) for f in HARD_BAD_FLAGS)
+    has_threat_evidence = has_confirmed_bad or has_suspicious_cat or has_bad_flags
+
+    # Gate 1 — unknown: no data ≠ benign. `known` is node existence, not explain().found.
+    if not explain_row.get('available', False) or not known:
+        return 'unknown'
+
+    # Gate 2 — known_good: a positive trust signal AND no threat evidence to override it.
+    trust_only = bool(sources) and all(c in TRUST_CATEGORIES for c in categories)
+    has_trust_signal = (
+        explain_row.get('advisory') == 'allowlist-vouched' or flags.get('isWhitelist') or trust_only
+    )
+    if has_trust_signal and not has_threat_evidence and level not in ('HIGH', 'CRITICAL'):
+        return 'known_good'
+
+    # Gate 3 — known_bad: a confirmed-malicious node flag on its own (#30 — the node IS bad
+    # infrastructure: C2/malware/phishing/botnet/exfil/OFAC-sanctioned/state-actor), OR the
+    # classic severity+confirmed-bad-category combination.
+    if has_hard_bad_flag or (level in ('HIGH', 'CRITICAL') and has_confirmed_bad):
+        return 'known_bad'
+
+    # Gate 4 — suspicious: a real score band, or any threat evidence short of confirmed-bad.
+    if level in ('LOW', 'MEDIUM', 'HIGH', 'CRITICAL') or has_threat_evidence:
+        return 'suspicious'
+
+    # Found, but only trust/neutral/no evidence and no score band → unknown, not known_good.
+    return 'unknown'
+
+
+# --- threat_feed / tags fragments -----------------------------------------------------------
+def build_threat_feed(sources: 'list[dict]', flags: dict) -> dict:
+    feeds = [str(s.get('feedId', '')) for s in sources]
+    categories = sorted({c for c in (feed_category(f) for f in feeds) if c})
+    true_flags = [f for f in THREAT_FLAGS if flags.get(f)]
+    # ISO-8601 strings compare lexicographically — min/max are chronological.
+    firsts = [s['firstSeen'] for s in sources if s.get('firstSeen')]
+    lasts = [s['lastSeen'] for s in sources if s.get('lastSeen')]
+    return {
+        'feeds': feeds,
+        'categories': categories,
+        'flags': true_flags,
+        'sources_count': len(feeds),
+        'first_seen': min(firsts) if firsts else None,
+        'last_seen': max(lasts) if lasts else None,
+    }
+
+
+def build_tags(flags: dict, categories: 'list[str]') -> 'list[str]':
+    tags = {TAG_BY_FLAG[f] for f in TAG_BY_FLAG if flags.get(f)}
+    category_tags = {
+        'Phishing': 'phishing',
+        'C2 Servers': 'c2',
+        'Malware Distribution': 'malware',
+        'Brute Force': 'bruteforce',
+        'TOR Network': 'tor',
+        'Proxies': 'proxy',
+        'VPNs': 'vpn',
+        'Spam': 'spam',
+        'OFAC SDN Sanctions': 'ofac-sanctioned',
+    }
+    tags.update(category_tags[c] for c in categories if c in category_tags)
+    return sorted(tags)
+
+
+# --- IP enrichment (mapping §5.1/§5.3) -------------------------------------------------------
+_ASN_NUM_RE = re.compile(r'^AS(\d+)$')
+# No direct IP→ASN edge: BELONGS_TO→PREFIX←ROUTES−ASN; human name via HAS_NAME (nullable —
+# verified: AS60729 has no ASN_NAME). IPv6 has no HAS_COUNTRY edge — country via ASN/CITY.
+# Registered-PREFIX threat props (#29) ride the SAME traversal — no extra round-trip. Verified
+# live 2026-07-11: the PREFIX carries its own threatLevel/isThreat (185.220.101.0/24 → CRITICAL)
+# independent of the ASN aggregate (AS60729 → NONE), so the granular /prefix/ signal is the
+# actionable one. The ASN-level aggregate was evaluated and deliberately NOT emitted: only 2 of
+# 116k ASNs carry a non-NONE level, while hasThreateningPrefixes/score>0 fire for benign
+# hyperscalers (Google's AS15169 → score 1, has_threatening true) — too noisy to be useful, and
+# asn.reputation already scores the ASN.
+_IP_THREAT_RETURN = (
+    'p.threatLevel AS prefix_threat_level, p.threatScore AS prefix_threat_score, '
+    'p.isThreat AS prefix_is_threat, p.threatNeighborCount AS prefix_threat_neighbors'
+)
+_Q_IP_CONTEXT_V4 = (
+    'MATCH (ip:IPV4 {name: $v}) '
+    'OPTIONAL MATCH (ip)-[:BELONGS_TO]->(p:PREFIX)<-[:ROUTES]-(a:ASN) '
+    'OPTIONAL MATCH (a)-[:HAS_NAME]->(an:ASN_NAME) '
+    'OPTIONAL MATCH (a)-[:HAS_COUNTRY]->(ac:COUNTRY) '
+    'OPTIONAL MATCH (ip)-[:HAS_COUNTRY]->(c:COUNTRY) '
+    'OPTIONAL MATCH (ip)-[:LOCATED_IN]->(city:CITY) '
+    'RETURN p.name AS prefix, a.name AS asn, an.name AS asn_name, '
+    'ac.name AS asn_country, c.name AS country, city.name AS city, ' + _IP_THREAT_RETURN + ' LIMIT 1'
+)
+_Q_IP_CONTEXT_V6 = (
+    'MATCH (ip:IPV6 {name: $v}) '
+    'OPTIONAL MATCH (ip)-[:BELONGS_TO]->(p:PREFIX)<-[:ROUTES]-(a:ASN) '
+    'OPTIONAL MATCH (a)-[:HAS_NAME]->(an:ASN_NAME) '
+    'OPTIONAL MATCH (a)-[:HAS_COUNTRY]->(ac:COUNTRY) '
+    'OPTIONAL MATCH (ip)-[:LOCATED_IN]->(city:CITY) '
+    'RETURN p.name AS prefix, a.name AS asn, an.name AS asn_name, '
+    'ac.name AS asn_country, city.name AS city, ' + _IP_THREAT_RETURN + ' LIMIT 1'
+)
+
+
+# Threat levels that carry no actionable signal — used to keep benign infra out of the
+# envelope (a clean IP must not sprout an empty asn.threat / prefix_threat block).
+_QUIET_LEVELS = frozenset({None, 'NONE', 'INFO', 'UNKNOWN'})
+
+
+def _num(value: 'object') -> 'int | float | None':
+    """int/float pass-through (bool excluded — it is an int subclass); anything else → None.
+    Whisper returns threat scores as JSON numbers, so this is a type guard, not a parser."""
+    if isinstance(value, bool):
+        return None
+    return value if isinstance(value, (int, float)) else None
+
+
+def _prefix_threat(ctx: dict) -> 'dict | None':
+    """Registered-prefix threat props (#29) — the granular signal: a threat-listed /24 whose
+    ASN aggregate reads clean (verified 185.220.101.0/24 → CRITICAL under AS60729 → NONE).
+    Same gate as the ASN: a benign prefix stays out of the envelope."""
+    level = ctx.get('prefix_threat_level')
+    score = _num(ctx.get('prefix_threat_score'))
+    is_threat = ctx.get('prefix_is_threat') is True
+    if not (is_threat or (score is not None and score > 0) or level not in _QUIET_LEVELS):
+        return None
+    out: dict = {}
+    if level and level not in _QUIET_LEVELS:
+        out['level'] = level
+    if score is not None:
+        out['score'] = score
+    if is_threat:
+        out['is_threat'] = True
+    neighbors = _num(ctx.get('prefix_threat_neighbors'))
+    if neighbors is not None:
+        out['threat_neighbor_count'] = neighbors
+    return out or None
+
+
+# Opt-in Tier-2 (#32): TLS-fingerprint clustering. Verified live 2026-07-12 that 100% of
+# EMITS_TLS_FINGERPRINT edges resolve to jarm/cobalt-strike-default, and ~97% of emitters read
+# clean in the threat feeds — so this catches C2 the feed layer misses. The two hops MUST be
+# split by `WITH t`: a single (ip)-[..]->(t)<-[..]-(co) pattern silently returns 0 rows. Emitted
+# only when the edge exists (the catalog is a frozen, sparse snapshot — never render absence).
+_Q_TLS_FINGERPRINT = (
+    'MATCH (ip:IPV4 {name: $v})-[:EMITS_TLS_FINGERPRINT]->(t:TLS_FINGERPRINT) '
+    'WITH t '
+    'MATCH (t)<-[:EMITS_TLS_FINGERPRINT]-(co:IPV4) '
+    'RETURN t.name AS fingerprint, t.kind AS kind, t.family AS family, '
+    'count(DISTINCT co) AS cluster_size ORDER BY cluster_size DESC'
+)
+
+
+def build_tls_fragment(cfg: dict, ioc: str) -> 'dict | None':
+    """TLS-fingerprint cluster for an IPv4, or None when the IP emits no fingerprint (#32).
+
+    `cluster_size` = how many IPs share this fingerprint — NOT a count of known-bad hosts
+    (co-emitters carry no independent feed signal; they are fellow-suspected CS servers by the
+    same JARM). `family` (e.g. cobalt-strike-default) is the actionable label a rule keys on.
+    """
+    rows = execute_query(
+        cfg['api_url'], cfg['api_key'], _Q_TLS_FINGERPRINT, {'v': ioc}, cfg['timeout'], cfg['retries']
+    )
+    if not rows:
+        return None
+    top = rows[0]
+    tls: dict = {}
+    if top.get('fingerprint'):
+        tls['fingerprint'] = top['fingerprint']
+    if top.get('kind'):
+        tls['kind'] = top['kind']
+    if top.get('family'):
+        tls['family'] = top['family']
+    if isinstance(top.get('cluster_size'), int):
+        tls['cluster_size'] = top['cluster_size']
+    if len(rows) > 1:  # IP emits multiple fingerprints — surface the top, note the rest
+        tls['count'] = len(rows)
+    return tls or None
+
+
+def build_ip_fragments(cfg: dict, ioc: str, ioc_type: str, flags: dict, notes: 'list[str]') -> dict:
+    cypher = _Q_IP_CONTEXT_V4 if ioc_type == 'ipv4' else _Q_IP_CONTEXT_V6
+    rows = execute_query(cfg['api_url'], cfg['api_key'], cypher, {'v': ioc}, cfg['timeout'], cfg['retries'])
+    ctx = rows[0] if rows else {}
+
+    asn_obj: 'dict | None' = None
+    asn_raw = ctx.get('asn')
+    if isinstance(asn_raw, str):
+        match = _ASN_NUM_RE.match(asn_raw)
+        if match:
+            asn_obj = {'number': int(match.group(1)), 'name': ctx.get('asn_name')}
+            country = ctx.get('asn_country')
+            if country:
+                asn_obj['country'] = country
+            # ASN reputation: breakdown from explain(asn) — the top-level score reflects
+            # only direct feed listing (often 0); the actionable signal is the breakdown.
+            # Auth errors must still terminate the run (never swallowed into a note).
+            try:
+                rep = call_explain(cfg, asn_raw)
+                if rep.get('breakdown'):
+                    asn_obj['reputation'] = rep['breakdown']
+            except (WhisperTransportError, WhisperQueryError):
+                notes.append('asn reputation lookup failed')
+
+    geo = {}
+    country = ctx.get('country') or ctx.get('asn_country')
+    if country:
+        geo['country'] = country
+    if ctx.get('city'):
+        geo['city'] = ctx['city']
+
+    fragments: dict = {}
+    if asn_obj:
+        fragments['asn'] = asn_obj
+    if ctx.get('prefix'):
+        fragments['prefix'] = ctx['prefix']
+    prefix_threat = _prefix_threat(ctx)
+    if prefix_threat:
+        fragments['prefix_threat'] = prefix_threat
+    if geo:
+        fragments['geo'] = geo
+    # Opt-in TLS fingerprint (#32) — own try so a failure never drops asn/prefix/geo above.
+    # IPv4 only (all EMITS_TLS_FINGERPRINT edges are on IPV4). Auth errors still propagate.
+    if ioc_type == 'ipv4' and 'tls_fingerprint' in cfg.get('extra', frozenset()):
+        try:
+            tls = build_tls_fragment(cfg, ioc)
+            if tls:
+                fragments['tls'] = tls
+        except (WhisperTransportError, WhisperQueryError):
+            notes.append('tls fingerprint lookup failed')
+    # related.neighbors[] (reverse RESOLVES_TO / co-hosting) is deferred graph-wide — a plain
+    # reverse traversal is rejected as an unanchored 2.6B-node scan (mapping §11 Q4). It is a
+    # known non-goal, not per-alert unmapped data, so it is NOT noted here (keeps
+    # unmapped_summary absent for a clean IP — matching the §4.1 example).
+    return fragments
+
+
+# --- domain enrichment (mapping §5.2 — one anchored DIRECTIONAL query per category) ----------
+LIST_CAP = 25
+WHOIS_CAP = 10
+ORG_CAP = 5
+# The engine clamps LIMIT to 500 (live CLAMP_LIMIT rewrite, verified 2026-07-06), so a
+# bounded count maxes at 500; a total == 500 means "≥500, capped" (mapping §8 truncation).
+LINKS_COUNT_CAP = 500
+# Templates carry a {cap} placeholder so the reader queries cap+1 and can detect truncation
+# (an integer constant — safe to inline). NS/MX point neighbour→seed: own records via `<-`.
+_Q_DNS = {
+    'a': 'MATCH (d:HOSTNAME {{name: $v}})-[:RESOLVES_TO]->(m:IPV4) WITH m LIMIT {cap} RETURN m.name AS name',
+    'aaaa': 'MATCH (d:HOSTNAME {{name: $v}})-[:RESOLVES_TO]->(m:IPV6) WITH m LIMIT {cap} RETURN m.name AS name',
+    'cname': 'MATCH (d:HOSTNAME {{name: $v}})-[:ALIAS_OF]->(m:HOSTNAME) WITH m LIMIT {cap} RETURN m.name AS name',
+    'ns': 'MATCH (d:HOSTNAME {{name: $v}})<-[:NAMESERVER_FOR]-(m:HOSTNAME) WITH m LIMIT {cap} RETURN m.name AS name',
+    'mx': 'MATCH (d:HOSTNAME {{name: $v}})<-[:MAIL_FOR]-(m:HOSTNAME) WITH m LIMIT {cap} RETURN m.name AS name',
+}
+# Query registrar BEFORE previous-registrar; first-writer-wins when the same node
+# appears under both edges (opencti #61 ordering discipline).
+_Q_WHOIS_REGISTRARS = (
+    'MATCH (d:HOSTNAME {name: $v}) '
+    'OPTIONAL MATCH (d)-[:HAS_REGISTRAR]->(r:REGISTRAR) '
+    'OPTIONAL MATCH (d)-[:PREV_REGISTRAR]->(pr:REGISTRAR) '
+    'RETURN r.name AS registrar, pr.name AS previous LIMIT 1'
+)
+_Q_WHOIS_ORG = 'MATCH (d:HOSTNAME {{name: $v}})-[:REGISTERED_BY]->(o:ORGANIZATION) WITH o LIMIT {cap} RETURN o.name AS name'
+_Q_WHOIS_EMAIL = (
+    'MATCH (d:HOSTNAME {{name: $v}})-[:HAS_EMAIL]->(m:EMAIL) WITH m LIMIT {cap} RETURN m.name AS name'
+)
+_Q_WHOIS_PHONE = (
+    'MATCH (d:HOSTNAME {{name: $v}})-[:HAS_PHONE]->(m:PHONE) WITH m LIMIT {cap} RETURN m.name AS name'
+)
+_Q_SPF = {
+    'include': 'MATCH (d:HOSTNAME {{name: $v}})-[:SPF_INCLUDE]->(m) WITH m LIMIT {cap} RETURN m.name AS name',
+    'a': 'MATCH (d:HOSTNAME {{name: $v}})-[:SPF_A]->(m) WITH m LIMIT {cap} RETURN m.name AS name',
+    'mx': 'MATCH (d:HOSTNAME {{name: $v}})-[:SPF_MX]->(m) WITH m LIMIT {cap} RETURN m.name AS name',
+    'ip': 'MATCH (d:HOSTNAME {{name: $v}})-[:SPF_IP]->(m) WITH m LIMIT {cap} RETURN m.name AS name',
+    'exists': 'MATCH (d:HOSTNAME {{name: $v}})-[:SPF_EXISTS]->(m) WITH m LIMIT {cap} RETURN m.name AS name',
+}
+_Q_SPF_REDIRECT = 'MATCH (d:HOSTNAME {name: $v})-[:SPF_REDIRECT]->(m) RETURN m.name AS name LIMIT 1'
+_Q_LINKS_OUT = (
+    'MATCH (d:HOSTNAME {{name: $v}})-[:LINKS_TO]->(o:HOSTNAME) WITH o LIMIT {cap} RETURN o.name AS name'
+)
+_Q_LINKS_IN = (
+    'MATCH (d:HOSTNAME {{name: $v}})<-[:LINKS_TO]-(o:HOSTNAME) WITH o LIMIT {cap} RETURN o.name AS name'
+)
+# Exact counts error on hub domains (collect >1M) — bounded count (engine clamps to 500).
+_Q_LINKS_OUT_COUNT = (
+    'MATCH (d:HOSTNAME {name: $v})-[:LINKS_TO]->(o:HOSTNAME) WITH o LIMIT 500 RETURN count(o) AS c'
+)
+_Q_LINKS_IN_COUNT = (
+    'MATCH (d:HOSTNAME {name: $v})<-[:LINKS_TO]-(o:HOSTNAME) WITH o LIMIT 500 RETURN count(o) AS c'
+)
+# #30 — of the (bounded) outbound links, how many target a threat-listed domain. Guilt by
+# association: a page linking out to known-bad hosts. Verified live 2026-07-11 (google.com → 1).
+_Q_LINKS_OUT_SUSPICIOUS_COUNT = (
+    'MATCH (d:HOSTNAME {name: $v})-[:LINKS_TO]->(o:HOSTNAME) '
+    'WHERE o.isThreat WITH o LIMIT 500 RETURN count(o) AS c'
+)
+
+
+def _names(cfg: dict, cypher: str, ioc: str) -> 'list[str]':
+    """Names from a plain (already-LIMITed) template — no truncation tracking."""
+    rows = execute_query(cfg['api_url'], cfg['api_key'], cypher, {'v': ioc}, cfg['timeout'], cfg['retries'])
+    return [r['name'] for r in rows if isinstance(r.get('name'), str)]
+
+
+def _capped_names(
+    cfg: dict, template: str, ioc: str, cap: int, label: str, trunc: 'list[str]'
+) -> 'list[str]':
+    """Names from a {cap}-templated query, capped at `cap`. Queries cap+1 to DETECT
+    truncation; records the field label in `trunc` and slices to `cap` when there are more."""
+    rows = execute_query(
+        cfg['api_url'],
+        cfg['api_key'],
+        template.format(cap=cap + 1),
+        {'v': ioc},
+        cfg['timeout'],
+        cfg['retries'],
+    )
+    names = [r['name'] for r in rows if isinstance(r.get('name'), str)]
+    if len(names) > cap:
+        trunc.append(label)
+        return names[:cap]
+    return names
+
+
+def _count_capped(cfg: dict, cypher: str, ioc: str) -> 'tuple[int, bool]':
+    """(count, at_cap). at_cap True when the engine-clamped count hit LINKS_COUNT_CAP."""
+    rows = execute_query(cfg['api_url'], cfg['api_key'], cypher, {'v': ioc}, cfg['timeout'], cfg['retries'])
+    value = rows[0].get('c') if rows else 0
+    count = value if isinstance(value, int) else 0
+    return count, count >= LINKS_COUNT_CAP
+
+
+# --- domain variants (no LOOKALIKE_OF edge — generate in-process, confirm registration) ------
+_HOMOGLYPHS = {'o': '0', 'l': '1', 'i': '1', 'e': '3', 'a': '4', 's': '5', 'g': '9', 'b': '8'}
+_VARIANT_TLDS = ('com', 'net', 'org', 'info', 'co', 'io', 'xyz', 'top')
+MAX_VARIANT_CANDIDATES = 60
+VARIANTS_CAP = 25
+
+
+def registrable_domain(domain: str) -> 'str | None':
+    """The registrable apex to squat on: (sld, tld) → 'sld.tld'. Heuristic — the last two
+    labels; a full PSL is out of MVP scope, so multi-part suffixes (co.uk) squat the
+    second level (documented). Reduces subdomains (www.evil.com → evil.com) so variants
+    mutate the real registrable label, not 'www'."""
+    parts = [p for p in domain.split('.') if p]
+    if len(parts) < 2:
+        return None
+    return '.'.join(parts[-2:])
+
+
+def generate_domain_variants(domain: str) -> 'list[tuple[str, str, float]]':
+    """Bounded typosquat candidates: [(variant, method, confidence), ...] — opencti's
+    generator ported. Operates on the REGISTRABLE domain (not a subdomain label).
+    `exists` ≠ malicious; registration is confirmed separately."""
+    apex = registrable_domain(domain)
+    if apex is None:
+        return []
+    label, _, rest = apex.partition('.')
+    seen: set[str] = {domain, apex}
+    out: list[tuple[str, str, float]] = []
+
+    def add(candidate: str, method: str, confidence: float) -> None:
+        if candidate not in seen and len(out) < MAX_VARIANT_CANDIDATES:
+            seen.add(candidate)
+            out.append((candidate, method, confidence))
+
+    for i, ch in enumerate(label):
+        if ch in _HOMOGLYPHS:
+            add(f'{label[:i]}{_HOMOGLYPHS[ch]}{label[i + 1 :]}.{rest}', 'homoglyph', 0.9)
+    if len(label) > 2:
+        for i in range(len(label)):
+            add(f'{label[:i]}{label[i + 1 :]}.{rest}', 'omission', 0.7)
+    for i in range(len(label) - 1):
+        swapped = f'{label[:i]}{label[i + 1]}{label[i]}{label[i + 2 :]}'
+        add(f'{swapped}.{rest}', 'transposition', 0.7)
+    for i, ch in enumerate(label):
+        add(f'{label[:i]}{ch}{ch}{label[i + 1 :]}.{rest}', 'repetition', 0.7)
+    for tld in _VARIANT_TLDS:
+        if rest != tld:
+            add(f'{label}.{tld}', 'tld-swap', 0.5)
+    for i in range(1, len(label)):
+        add(f'{label[:i]}-{label[i:]}.{rest}', 'hyphenation', 0.3)
+    return out
+
+
+def confirm_variants(
+    cfg: dict, candidates: 'list[tuple[str, str, float]]', trunc: 'list[str]'
+) -> 'list[dict]':
+    """One UNWIND existence query; only REGISTERED variants survive."""
+    if not candidates:
+        return []
+    rows = execute_query(
+        cfg['api_url'],
+        cfg['api_key'],
+        'UNWIND $cands AS v MATCH (h:HOSTNAME {name: v}) RETURN h.name AS name',
+        {'cands': [c[0] for c in candidates]},
+        cfg['timeout'],
+        cfg['retries'],
+    )
+    existing = {r['name'] for r in rows if isinstance(r.get('name'), str)}
+    confirmed = [{'variant': v, 'method': m, 'confidence': c} for v, m, c in candidates if v in existing]
+    if len(confirmed) > VARIANTS_CAP:
+        trunc.append('variants')
+    return confirmed[:VARIANTS_CAP]
+
+
+def build_domain_fragments(cfg: dict, ioc: str, notes: 'list[str]', trunc: 'list[str]') -> dict:
+    fragments: dict = {
+        'dns': {
+            key: _capped_names(cfg, tpl, ioc, LIST_CAP, f'dns.{key}', trunc) for key, tpl in _Q_DNS.items()
+        },
+    }
+
+    reg_rows = execute_query(
+        cfg['api_url'], cfg['api_key'], _Q_WHOIS_REGISTRARS, {'v': ioc}, cfg['timeout'], cfg['retries']
+    )
+    reg = reg_rows[0] if reg_rows else {}
+    registrar = reg.get('registrar')
+    previous = reg.get('previous')
+    if previous == registrar:
+        previous = None  # first-writer-wins: current state owns the shared node
+    orgs = _capped_names(cfg, _Q_WHOIS_ORG, ioc, ORG_CAP, 'whois.registered_by', trunc)
+    if len(orgs) > 1:
+        notes.append(f'{len(orgs) - 1} additional registrant org(s) not mapped')
+    fragments['whois'] = {
+        'registrar': registrar,
+        'previous_registrar': previous,
+        'registered_by': orgs[0] if orgs else None,
+        'email': _capped_names(cfg, _Q_WHOIS_EMAIL, ioc, WHOIS_CAP, 'whois.email', trunc),
+        'phone': _capped_names(cfg, _Q_WHOIS_PHONE, ioc, WHOIS_CAP, 'whois.phone', trunc),
+    }
+
+    spf = {key: _capped_names(cfg, tpl, ioc, LIST_CAP, f'spf.{key}', trunc) for key, tpl in _Q_SPF.items()}
+    redirect = _names(cfg, _Q_SPF_REDIRECT, ioc)
+    spf['redirect'] = redirect[0] if redirect else None
+    fragments['spf'] = spf
+
+    out_names = _capped_names(cfg, _Q_LINKS_OUT, ioc, LIST_CAP, 'links.outbound', trunc)
+    in_names = _capped_names(cfg, _Q_LINKS_IN, ioc, LIST_CAP, 'links.inbound', trunc)
+    out_total, out_capped = _count_capped(cfg, _Q_LINKS_OUT_COUNT, ioc)
+    in_total, in_capped = _count_capped(cfg, _Q_LINKS_IN_COUNT, ioc)
+    if out_capped:
+        trunc.append('links.outbound_total')
+    if in_capped:
+        trunc.append('links.inbound_total')
+    fragments['links'] = {
+        'outbound': out_names,
+        'outbound_total': out_total,
+        'inbound': in_names,
+        'inbound_total': in_total,
+    }
+    # Threat-linked outbound targets (#30) — emitted only when non-zero (a clean domain
+    # stays quiet; the vast majority link out to nothing threat-listed).
+    suspicious_out, _ = _count_capped(cfg, _Q_LINKS_OUT_SUSPICIOUS_COUNT, ioc)
+    if suspicious_out > 0:
+        fragments['links']['suspicious_count'] = suspicious_out
+
+    fragments['variants'] = confirm_variants(cfg, generate_domain_variants(ioc), trunc)
+    return fragments
+
+
+# --- envelope assembly & payload guard (mapping §4.2 / §8) -----------------------------------
+MAX_PAYLOAD_BYTES = 60 * 1024
+FRAMING_MARGIN = 1024  # headroom for the Form-B location prefix + integration wrapper (#16)
+_GRANULARITY = {'ipv4': 'ipv4', 'ipv6': 'ipv6', 'domain': 'hostname'}
+# Optional list fields, largest-first, dropped when over budget; core verdict/evidence
+# fields are never dropped. spf.* is included (six lists) so a pathological SPF graph can
+# still be trimmed.
+_DROP_ORDER = (
+    ('links', 'outbound'),
+    ('links', 'inbound'),
+    ('variants', None),
+    ('spf', 'include'),
+    ('spf', 'ip'),
+    ('spf', 'a'),
+    ('spf', 'mx'),
+    ('spf', 'exists'),
+    ('whois', 'email'),
+    ('whois', 'phone'),
+    ('dns', 'a'),
+    ('dns', 'aaaa'),
+    ('dns', 'ns'),
+    ('dns', 'mx'),
+    ('dns', 'cname'),
+    ('threat_feed', 'feeds'),
+)
+# Never dropped by the last-resort core reduction.
+_CORE_KEYS = frozenset(
+    {
+        'schema_version',
+        'ioc',
+        'type',
+        'known',
+        'available',
+        'verdict',
+        'risk_score',
+        'level',
+        'advisory',
+        'permalink',
+        'graph_node_id',
+        'source_ref',
+        'coverage',
+        'dedup_key',
+        'tags',
+        'threat_feed',
+        'unmapped_summary',
+        'truncated',
+    }
+)
+
+
+def _payload_size(payload: dict) -> int:
+    return len(json.dumps(payload, separators=(',', ':')).encode('utf-8'))
+
+
+def _over_budget(payload: dict) -> bool:
+    # Budget the WHOLE datagram incl. the {'integration': ...} wrapper + framing headroom.
+    return _payload_size(payload) + FRAMING_MARGIN > MAX_PAYLOAD_BYTES
+
+
+def fit_payload(payload: dict, notes: 'list[str]') -> dict:
+    """Enforce the 60 KB budget (mapping §8): drop the largest optional lists first, then —
+    as a last resort — reduce to the core verdict/evidence fields. Every drop is recorded;
+    never a silent truncation, never a failed send. `payload` is the full injected dict."""
+    whisper = payload['whisper']
+    for section, key in _DROP_ORDER:
+        if not _over_budget(payload):
+            break
+        container = whisper.get(section)
+        if key is None and whisper.get(section):
+            whisper[section] = []
+            whisper['truncated'] = True
+            notes.append(f'{section} dropped (payload budget)')
+        elif isinstance(container, dict) and container.get(key):
+            container[key] = []
+            whisper['truncated'] = True
+            notes.append(f'{section}.{key} dropped (payload budget)')
+
+    if _over_budget(payload):
+        for k in [k for k in whisper if k not in _CORE_KEYS]:
+            whisper.pop(k, None)
+        whisper['truncated'] = True
+        notes.append('reduced to core (payload budget)')
+
+    if _over_budget(payload):
+        notes.append('payload_too_large')
+    return payload
+
+
+def enrich(
+    ioc: str,
+    ioc_type: str,
+    dedup_key: str,
+    source_ref: dict,
+    api_url: str,
+    api_key: 'str | None',
+    timeout: int,
+    retries: int,
+    extra: 'frozenset[str]' = frozenset(),
+) -> dict:
+    """Build the full injection payload ({'integration': ..., 'whisper': {...}}) for one IOC.
+
+    explain() is the authoritative verdict source (threat evidence from sources[], never
+    Cypher LISTED_IN) and is FAIL-HARD — the verdict depends on it. The category fragments
+    are best-effort: a transport/query failure in any auxiliary query degrades with a note
+    rather than discarding an already-computed verdict (auth errors still terminate). The
+    whole datagram respects the 60 KB socket budget.
+    """
+    cfg = {'api_url': api_url, 'api_key': api_key, 'timeout': timeout, 'retries': retries, 'extra': extra}
+    notes: list[str] = []
+    trunc: list[str] = []
+
+    explain_row = call_explain(cfg, ioc)  # fail-hard
+    available = bool(explain_row.get('available', False))
+    granularity = _GRANULARITY[ioc_type]
+    kind = 'domain' if ioc_type == 'domain' else 'ip'
+    if explain_row.get('retryAfter') is not None:
+        notes.append(f'scoring degraded (retryAfter={explain_row["retryAfter"]})')
+
+    whisper: dict = {
+        'schema_version': '1.0',
+        'ioc': ioc,
+        'type': ioc_type,
+        'known': False,  # set from real node existence below (explain().found is unreliable)
+        'available': available,
+        'verdict': 'unknown',
+        'risk_score': float(explain_row.get('score') or 0.0),
+        'level': str(explain_row.get('level') or 'NONE'),
+        'advisory': explain_row.get('advisory'),
+        'permalink': f'{api_url}/{kind}/{ioc}',
+        'graph_node_id': None,
+        'source_ref': source_ref,
+        # The REST layer has no coverage block (MCP-surface only): granularity is
+        # derived from the IOC type; shared_host/data_coverage stay None here and are
+        # stripped before send (nullable fields are omitted, never JSON null — §2.4).
+        'coverage': {'granularity': granularity, 'shared_host': None, 'data_coverage': None},
+        'dedup_key': dedup_key,
+        'unmapped_summary': None,
+        'truncated': False,
+    }
+    payload = {'integration': INTEGRATION_NAME, 'whisper': whisper}
+
+    # A feed listing proves the node exists (you can't be listed without one); otherwise
+    # node existence is confirmed by fetch_flags. Both are best-effort past the verdict.
+    sources = explain_row.get('sources') or []
+    flags: dict = {}
+    known = bool(sources)
+    if available:
+        try:
+            node = fetch_flags(cfg, ioc, ioc_type)  # None → no node
+            known = known or node is not None
+            flags = node or {}
+        except (WhisperTransportError, WhisperQueryError) as exc:
+            notes.append(f'flags unavailable ({exc.log_class})')  # known may still hold via sources
+        whisper['known'] = known
+        if known:
+            whisper['graph_node_id'] = f'{granularity}/{ioc}'
+            threat_feed = build_threat_feed(sources, flags)
+            whisper['threat_feed'] = threat_feed
+            whisper['tags'] = build_tags(flags, threat_feed['categories'])
+            try:
+                if ioc_type == 'domain':
+                    whisper.update(build_domain_fragments(cfg, ioc, notes, trunc))
+                else:
+                    whisper.update(build_ip_fragments(cfg, ioc, ioc_type, flags, notes))
+            except (WhisperTransportError, WhisperQueryError) as exc:
+                # Context fragments are best-effort — keep the verdict + threat_feed.
+                notes.append(f'context enrichment degraded ({exc.log_class})')
+
+    if trunc:
+        whisper['truncated'] = True
+        notes.append(f'lists truncated: {", ".join(sorted(set(trunc)))}')
+
+    whisper['verdict'] = derive_verdict(explain_row, flags, known)
+    if notes:
+        whisper['unmapped_summary'] = '; '.join(notes)
+    # Strip nulls BEFORE the budget check so fit_payload measures the bytes actually sent
+    # (nulls about to be deleted must not trigger spurious trimming at the boundary).
+    payload = strip_nulls(payload)
+    whisper = payload['whisper']  # strip_nulls returns new dicts — rebind before mutating
+    fit_payload(payload, notes)  # may append further drop notes...
+    if notes:  # ...so refresh the summary after fitting
+        whisper['unmapped_summary'] = '; '.join(notes)
+    return payload
+
+
+def strip_nulls(value):
+    """Recursively drop None values from the payload before it is framed.
+
+    analysisd's JSON decoder stringifies every leaf, so a JSON `null` would index as the
+    LITERAL keyword string "null" (verified live on 4.14.5 — issue #17). Nullable fields
+    (asn.name, advisory, graph_node_id, unmapped_summary, whois.*, spf.redirect, coverage.*)
+    are therefore OMITTED when unknown; empty lists are kept (stable structure, and they
+    index as no-value, not as a string).
+    """
+    if isinstance(value, dict):
+        return {k: strip_nulls(v) for k, v in value.items() if v is not None}
+    if isinstance(value, list):
+        return [strip_nulls(v) for v in value if v is not None]
+    return value
+
+
+# ==========================================================================================
+# #15 — persistent dedup cache (SQLite; mapping §7)
+# ==========================================================================================
+# integratord spawns this script PER matching alert, so an in-process cache never persists
+# between alerts (mapping §7.5). The cache is an on-disk SQLite DB at DEDUP_DB, shared across
+# invocations. Backend choice = SQLite (#12 Q2): stdlib, atomic commits, a busy_timeout so
+# concurrent script processes serialize writes, and flush == delete the file.
+#
+# HARD CONSTRAINT — DO NOT enable `PRAGMA journal_mode=WAL`. The flush contract (`rm dedup.db*`)
+# and per-commit durability both depend on the DEFAULT rollback journal: WAL would create
+# persistent -wal/-shm sidecars that a bare flush wouldn't clear, and WAL's default
+# synchronous=NORMAL drops the fsync-per-commit that lets the NEXT spawned process see a record.
+#
+# READ/WRITE split (concurrency): check_dedup is a bare SELECT (shared read lock only) so pure
+# reads don't serialize against each other; pruning of expired rows happens in record_dedup,
+# which already holds a write lock — keeping the write lock OFF the hot read path.
+#
+# Fail-OPEN: any cache error makes check_dedup return False (do not suppress) and record_dedup
+# a silent no-op — a duplicate enrichment alert is far better than silently losing enrichment.
+DEDUP_BUSY_TIMEOUT = 5.0  # seconds a write waits on a concurrent writer before "database is locked"
+
+
+def _dedup_connect() -> 'sqlite3.Connection | None':
+    """Open (creating the dir + schema) the dedup DB, or None when it is unavailable."""
+    try:
+        os.makedirs(os.path.dirname(DEDUP_DB), exist_ok=True)
+        conn = sqlite3.connect(DEDUP_DB, timeout=DEDUP_BUSY_TIMEOUT)
+        conn.execute('CREATE TABLE IF NOT EXISTS dedup (key TEXT PRIMARY KEY, ts REAL NOT NULL)')
+        conn.execute('CREATE INDEX IF NOT EXISTS idx_dedup_ts ON dedup (ts)')  # for the prune
+        return conn
+    except (sqlite3.Error, OSError) as exc:
+        debug(f'whisper: dedup cache unavailable ({exc})')
+        return None
+
+
+def check_dedup(key: str, ttl: int) -> bool:
+    """True when `key` was recorded within `ttl` seconds → suppress this enrichment.
+
+    Read-only (no prune) so it takes only a shared lock. `ttl <= 0` disables dedup. Fails OPEN
+    (returns False) on any cache error. A future timestamp (`age < 0`, e.g. an NTP step-back) is
+    treated as NOT-suppressed so a clock anomaly can never hold back a real enrichment.
+
+    Best-effort, not exactly-once: two processes enriching the SAME IOC can both pass this check
+    before either records, and both emit — a rare duplicate under concurrency. The race can only
+    ever produce a duplicate, never suppress a legitimate first enrichment.
+    """
+    if ttl <= 0:
+        return False
+    conn = _dedup_connect()
+    if conn is None:
+        return False
+    try:
+        row = conn.execute('SELECT ts FROM dedup WHERE key = ?', (key,)).fetchone()
+    except sqlite3.Error as exc:
+        debug(f'whisper: dedup check failed ({exc})')
+        return False
+    finally:
+        conn.close()
+    if row is None:
+        return False
+    age = time.time() - row[0]
+    return 0 <= age < ttl
+
+
+def record_dedup(key: str, ttl: int = DEFAULT_DEDUP_TTL) -> None:
+    """Record `key` at the current time (mapping §7.3 step 3) and prune rows older than `ttl`.
+
+    Silent no-op on cache error. Called only AFTER a successful emit so failed enrichments stay
+    retryable within the TTL — recording earlier would cache failures (TC-09/TC-12 interaction).
+    Re-recording refreshes the timestamp; since duplicates are suppressed *before* emit, this
+    only fires on a genuine (first or post-expiry) emit — effectively one emit per TTL window,
+    reset at each emit.
+    """
+    conn = _dedup_connect()
+    if conn is None:
+        return
+    try:
+        now = time.time()
+        with conn:  # single write transaction: prune (housekeeping) + upsert
+            if ttl > 0:
+                conn.execute('DELETE FROM dedup WHERE ts < ?', (now - ttl,))
+            conn.execute('INSERT OR REPLACE INTO dedup (key, ts) VALUES (?, ?)', (key, now))
+    except sqlite3.Error as exc:
+        debug(f'whisper: dedup record failed ({exc})')
+    finally:
+        conn.close()
+
+
+# ==========================================================================================
+# #16 — analysisd socket write-back (mapping §2.3)
+# ==========================================================================================
+def frame_event(payload: dict, agent: 'dict | None') -> str:
+    """Frame the enrichment event for the analysisd queue socket (mapping §2.3).
+
+    Form A (manager/local — agent absent or id '000'):  `1:custom-whisper:<json>`
+    Form B (real originating agent — Q3 decision):        `1:<location>-><name>:<json>`
+      where location = `[<id>] (<name>) <ip|any>`, then `.replace('|','||').replace(':','|:')`
+      so colons/pipes inside it can't collide with the `1:...:` framing delimiters.
+
+    The leading `1` is the analysisd queue message type (a location-prefixed event). Compact
+    JSON separators keep the datagram small; no trailing newline.
+    """
+    body = json.dumps(payload, separators=(',', ':'))
+    if not agent or str(agent.get('id')) == '000':
+        return f'1:{INTEGRATION_NAME}:{body}'
+    location = f'[{agent.get("id")}] ({agent.get("name")}) {agent.get("ip") or "any"}'
+    location = location.replace('|', '||').replace(':', '|:')
+    return f'1:{location}->{INTEGRATION_NAME}:{body}'
+
+
+def send_event(payload: dict, alert_agent: 'dict | None') -> int:
+    """Frame + send the enrichment event to the analysisd socket; returns bytes sent.
+
+    Stamps the alert onto the originating agent (Form B, #12 Q3). Socket-layer failures
+    (missing socket, connect refused, errno 90 oversize) raise WhisperSocketError so
+    main()'s error taxonomy handles them uniformly (never an unhandled traceback).
+    """
+    encoded = frame_event(payload, alert_agent).encode('utf-8')
+    # Two independent ceilings: enrich() budgets the JSON body to ~60 KB (MAX_PAYLOAD_BYTES +
+    # FRAMING_MARGIN); this guard is the datagram hard limit (65535). fit_payload may still
+    # return an over-budget core payload tagged `payload_too_large`, so re-check here.
+    if len(encoded) > MAX_EVENT_SIZE:
+        raise WhisperSocketError(f'framed event {len(encoded)}B exceeds {MAX_EVENT_SIZE}B (errno 90)')
+    try:
+        # socket() is inside the try so an fd-exhaustion (EMFILE) OSError at construction is
+        # mapped to WhisperSocketError too — never an unhandled traceback.
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+        try:
+            sock.connect(SOCKET_ADDR)
+            sock.send(encoded)
+        finally:
+            sock.close()
+    except OSError as exc:
+        raise WhisperSocketError(f'analysisd socket send failed at {SOCKET_ADDR}: {exc}') from exc
+    return len(encoded)
+
+
+# --- entry point --------------------------------------------------------------------------
+def main(args: 'list[str]') -> int:
+    global debug_enabled
+
+    if len(args) < 4:
+        log_always('# Error: Wrong arguments')
+        return ERR_BAD_ARGUMENTS
+    debug_enabled = len(args) > DEBUG_INDEX and args[DEBUG_INDEX] == 'debug'
+
+    # Mirror stock get_json_alert(): missing file and corrupt JSON are distinct
+    # failures with distinct exit codes (6 vs 7) for standard Wazuh triage.
+    try:
+        alert = load_alert(args[ALERT_INDEX])
+    except FileNotFoundError:
+        log_always(f'# Error: Alert file not found: {args[ALERT_INDEX]}')
+        return ERR_FILE_NOT_FOUND
+    except json.JSONDecodeError as exc:
+        log_always(f'# Error: Invalid alert JSON: {exc}')
+        return ERR_INVALID_JSON
+
+    if is_self_alert(alert):
+        # Loop guard #3 (after the integration filter + rule-group separation) — mapping §8.
+        log_skip('self-alert')
+        return 0
+
+    # Extraction runs before any config I/O so no-IOC alerts exit without touching
+    # the options/key files (the common case under broad rule filters).
+    candidates = extract_iocs(alert)
+    if not candidates:
+        return 0
+
+    options = load_options(args[OPTIONS_INDEX] if len(args) > OPTIONS_INDEX else '')
+    api_url = resolve_api_url(options, os.environ)
+    dedup_ttl = resolve_dedup_ttl(options, os.environ)
+    include_agent = resolve_dedup_scope(options, os.environ)
+    extra = resolve_extra_enrichments(options, os.environ)
+    api_key = resolve_api_key(args[APIKEY_INDEX] if len(args) > APIKEY_INDEX else '', os.environ)
+    timeout = _argv_int(args, TIMEOUT_INDEX, DEFAULT_TIMEOUT)
+    retries = _argv_int(args, RETRIES_INDEX, DEFAULT_RETRIES)
+    agent_id = str(get_nested(alert, 'agent.id') or '000')
+
+    emitted = 0
+    errors = 0
+    for ioc, ioc_type, field_path in candidates:
+        key = make_dedup_key(ioc_type, ioc, agent_id, include_agent)
+        log_invoke(ioc, ioc_type, key)
+        if check_dedup(key, dedup_ttl):
+            log_skip('dedup', dedup_key=key)
+            continue
+        try:
+            payload = enrich(
+                ioc,
+                ioc_type,
+                key,
+                build_source_ref(alert, field_path),
+                api_url,
+                api_key,
+                timeout,
+                retries,
+                extra,
+            )
+            sent = send_event(payload, alert.get('agent'))
+            record_dedup(key, dedup_ttl)  # only after a successful emit — failures stay retryable
+            log_emit(key, sent)
+            emitted += 1
+        except WhisperAuthError as exc:
+            # Terminal: the same key fails for every remaining candidate — stop the run.
+            log_error(exc)
+            return ERR_AUTH
+        except WhisperError as exc:
+            log_error(exc)
+            errors += 1
+
+    # Exit 0 when anything landed (TC-15: a successful emit must not produce an
+    # 'Exit status was:' line in ossec.log); non-zero only for all-failure runs (TC-13).
+    return 0 if emitted or not errors else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/integrations/whisper/whisper-template.json
+++ b/integrations/whisper/whisper-template.json
@@ -1,0 +1,70 @@
+{
+  "order": 1,
+  "index_patterns": ["wazuh-alerts-4.x-*", "wazuh-archives-4.x-*"],
+  "mappings": {
+    "properties": {
+      "data": {
+        "properties": {
+          "whisper": {
+            "properties": {
+              "risk_score": { "type": "float", "ignore_malformed": true },
+              "known": { "type": "boolean" },
+              "available": { "type": "boolean" },
+              "truncated": { "type": "boolean" },
+              "coverage": {
+                "properties": {
+                  "shared_host": { "type": "boolean" }
+                }
+              },
+              "asn": {
+                "properties": {
+                  "number": { "type": "long", "ignore_malformed": true },
+                  "reputation": {
+                    "properties": {
+                      "threatDensityScore": { "type": "float", "ignore_malformed": true },
+                      "graphMetricsScore": { "type": "float", "ignore_malformed": true },
+                      "historicalScore": { "type": "float", "ignore_malformed": true },
+                      "prefixAgeScore": { "type": "float", "ignore_malformed": true }
+                    }
+                  }
+                }
+              },
+              "prefix_threat": {
+                "properties": {
+                  "score": { "type": "float", "ignore_malformed": true },
+                  "is_threat": { "type": "boolean" },
+                  "threat_neighbor_count": { "type": "long", "ignore_malformed": true }
+                }
+              },
+              "tls": {
+                "properties": {
+                  "cluster_size": { "type": "long", "ignore_malformed": true },
+                  "count": { "type": "long", "ignore_malformed": true }
+                }
+              },
+              "threat_feed": {
+                "properties": {
+                  "sources_count": { "type": "long", "ignore_malformed": true },
+                  "first_seen": { "type": "date", "ignore_malformed": true },
+                  "last_seen": { "type": "date", "ignore_malformed": true }
+                }
+              },
+              "links": {
+                "properties": {
+                  "inbound_total": { "type": "long", "ignore_malformed": true },
+                  "outbound_total": { "type": "long", "ignore_malformed": true },
+                  "suspicious_count": { "type": "long", "ignore_malformed": true }
+                }
+              },
+              "variants": {
+                "properties": {
+                  "confidence": { "type": "float", "ignore_malformed": true }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/integrations/whisper/whisper_client.py
+++ b/integrations/whisper/whisper_client.py
@@ -1,0 +1,298 @@
+"""whisper_client — shared stdlib HTTP/TLS/auth client for the Whisper API.
+
+Imported by BOTH the enrichment connector (custom-whisper.py, run per-alert by integratord)
+and the analyst CLI (whisper-investigate.py, run on demand). It holds the load-bearing
+operational knowledge that must live in exactly one place so it can never drift:
+  - the non-default User-Agent — the API WAF 403s urllib's default `Python-urllib/x.y`;
+  - the CA-bundle resolution — the Wazuh framework Python loads ZERO CAs by default, so a
+    verifying context has to locate a real bundle itself;
+  - the retry / Retry-After taxonomy and the Whisper* exception classes.
+
+Both callers install into /var/ossec/integrations/, so this module is a sibling on
+sys.path[0] at runtime — no path gymnastics. stdlib only (Python 3.10).
+
+Logging is decoupled: `log_api` defaults to a no-op here; the connector overrides
+`whisper_client.log_api` with its debug logger, and the CLI can point it at a verbose sink.
+"""
+
+import http.client
+import ipaddress  # noqa: F401 — re-exported for callers that build on parse_ip's return type
+import json
+import os
+import re
+import ssl
+import time
+import urllib.error
+import urllib.request
+from urllib.parse import urlsplit
+
+# --- paths & constants --------------------------------------------------------------------
+# Wazuh home is one level up from integrations/ (realpath so a symlinked install still
+# resolves inside /var/ossec — the stock virustotal.py idiom).
+_pwd = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+KEY_FILE = f'{_pwd}/etc/whisper.key'
+API_KEY_PLACEHOLDER = 'WHISPER_API_KEY_PLACEHOLDER'
+DEFAULT_API_URL = 'https://graph.whisper.security'
+DEFAULT_TIMEOUT = 10
+DEFAULT_RETRIES = 3
+
+API_QUERY_PATH = '/api/query'
+CONNECTOR_VERSION = '1.0'
+# Must NOT start with 'Python-urllib' — the Whisper API WAF blocks that default UA.
+USER_AGENT = f'whisper-wazuh-connector/{CONNECTOR_VERSION}'
+BACKOFF_BASE = 0.5
+BACKOFF_CAP = 60.0
+# Common CA-bundle locations, tried when the interpreter's compiled-in paths are empty.
+_CA_BUNDLE_CANDIDATES = (
+    '/etc/ssl/certs/ca-certificates.crt',  # Debian/Ubuntu (Wazuh manager image)
+    '/etc/pki/tls/certs/ca-bundle.crt',  # RHEL/CentOS
+    '/etc/ssl/cert.pem',  # Alpine/BSD
+)
+
+_DOMAIN_RE = re.compile(
+    r'^(?=.{1,253}$)(?:[a-z0-9_](?:[a-z0-9_-]{0,61}[a-z0-9_])?\.)+' r'(?:[a-z]{2,63}|xn--[a-z0-9-]{1,59})$'
+)
+
+
+# --- error taxonomy (mirrors whisper-opencti; drives the `error class=` log line) ---------
+class WhisperError(Exception):
+    """Base for Whisper-boundary failures."""
+
+    log_class = 'query'
+
+
+class WhisperAuthError(WhisperError):
+    """401/403 — terminal: the same key fails for every candidate, so stop the run."""
+
+    log_class = 'auth'
+
+
+class WhisperTransportError(WhisperError):
+    """Network / 5xx / 429-after-retries — transient."""
+
+    log_class = 'transport'
+
+
+class WhisperQueryError(WhisperError):
+    """Other 4xx / malformed body — likely a caller bug."""
+
+    log_class = 'query'
+
+
+# --- logging hook (overridable) -----------------------------------------------------------
+def log_api(url: str, ms: int) -> None:
+    """No-op by default. The connector overrides this with its debug logger; the CLI may
+    point it at a stderr/verbose sink. Keeping the client silent-by-default means importing
+    it never writes to a log file the caller didn't ask for."""
+
+
+# --- TLS / transport ----------------------------------------------------------------------
+def _ssl_context() -> 'ssl.SSLContext':
+    """A verifying TLS context that actually has CAs loaded, wherever the bundle lives.
+
+    Resolution: the interpreter default → `SSL_CERT_FILE` → well-known bundle paths → the
+    bundled `certifi` (ships with the framework Python). Verification stays ON throughout.
+    """
+    ctx = ssl.create_default_context()
+    if ctx.get_ca_certs():
+        return ctx
+    candidates = [os.environ.get('SSL_CERT_FILE'), *_CA_BUNDLE_CANDIDATES]
+    for path in candidates:
+        if path and os.path.exists(path):
+            try:
+                ctx.load_verify_locations(path)
+            except (ssl.SSLError, OSError):
+                continue
+            if ctx.get_ca_certs():  # an empty/placeholder PEM loads 0 certs without raising
+                return ctx
+    try:
+        import certifi  # bundled with the Wazuh framework Python; last-resort only
+
+        ctx.load_verify_locations(certifi.where())
+    except (ImportError, ssl.SSLError, OSError):
+        pass  # nothing found — verification will fail loudly (better than silently trusting all)
+    return ctx
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Never follow redirects. urllib's default handler re-sends ALL request headers (X-API-Key
+    is a custom header, so CPython's cross-origin Authorization-stripping does not cover it) on a
+    3xx — including an https->http downgrade — which would leak the API key to the redirect
+    target. Refusing to follow surfaces a 3xx as an HTTPError instead (handled below)."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def _http_post(url: str, body: dict, headers: dict, timeout: int) -> 'tuple[int, bytes, dict]':
+    """Thin transport seam (tests monkeypatch this). Returns (status, raw, lower-cased headers).
+
+    Generic POST-JSON: the connector uses it for /api/query, the CLI reuses it for the MCP
+    JSON-RPC endpoint — same TLS context, same WAF-safe requirement on the caller's UA header,
+    and redirects are never followed (the API key must not travel to a redirect target).
+    """
+    req = urllib.request.Request(url, data=json.dumps(body).encode('utf-8'), headers=headers, method='POST')
+    handlers: list = [_NoRedirect()]
+    if url.startswith('https'):
+        handlers.append(urllib.request.HTTPSHandler(context=_ssl_context()))
+    opener = urllib.request.build_opener(*handlers)
+    try:
+        with opener.open(req, timeout=timeout) as resp:  # noqa: S310 — https URL from config
+            return resp.status, resp.read(), {k.lower(): v for k, v in resp.headers.items()}
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read(), {k.lower(): v for k, v in (exc.headers or {}).items()}
+
+
+def _retry_after_seconds(headers: dict) -> 'float | None':
+    value = headers.get('retry-after')
+    if value is None:
+        return None
+    try:
+        return max(0.0, float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def execute_query(
+    api_url: str,
+    api_key: 'str | None',
+    cypher: str,
+    params: 'dict | None' = None,
+    timeout: int = DEFAULT_TIMEOUT,
+    retries: int = DEFAULT_RETRIES,
+) -> 'list[dict]':
+    """POST one Cypher query to /api/query; return `rows` (list of dicts keyed by column name).
+
+    Error taxonomy (drives the `error class=` log line):
+      401/403                    → WhisperAuthError (terminal)
+      429 / 5xx after retries    → WhisperTransportError (Retry-After honoured per attempt)
+      network failure            → WhisperTransportError
+      other 4xx / bad body       → WhisperQueryError
+    """
+    # An explicit User-Agent is REQUIRED: the Whisper API's WAF 403s urllib's default
+    # `Python-urllib/x.y` UA (verified live 2026-07-11). Any non-default UA passes.
+    headers = {'Content-Type': 'application/json', 'User-Agent': USER_AGENT}
+    if api_key:
+        headers['X-API-Key'] = api_key
+    body: dict = {'query': cypher}
+    if params:
+        body['parameters'] = params
+    url = f'{api_url}{API_QUERY_PATH}'
+
+    attempt = 0
+    while True:
+        started = time.monotonic()
+        try:
+            status, raw, resp_headers = _http_post(url, body, headers, timeout)
+        except (urllib.error.URLError, OSError, http.client.HTTPException) as exc:
+            # http.client.HTTPException (BadStatusLine/IncompleteRead) is NOT an OSError —
+            # catch it explicitly so a garbled response stays inside the retry budget and
+            # the taxonomy instead of crashing with an unhandled traceback.
+            log_api(api_url, int((time.monotonic() - started) * 1000))
+            if attempt < retries:
+                attempt += 1
+                time.sleep(min(BACKOFF_BASE * (2 ** (attempt - 1)), BACKOFF_CAP))
+                continue
+            raise WhisperTransportError(f'network error after {retries} retries: {exc}') from exc
+        log_api(api_url, int((time.monotonic() - started) * 1000))
+
+        if status in (401, 403):
+            raise WhisperAuthError(f'HTTP {status} from Whisper API')
+        if status == 429 or status >= 500:
+            if attempt < retries:
+                attempt += 1
+                delay = _retry_after_seconds(resp_headers)
+                if delay is None:
+                    delay = BACKOFF_BASE * (2 ** (attempt - 1))
+                time.sleep(min(delay, BACKOFF_CAP))
+                continue
+            raise WhisperTransportError(f'HTTP {status} after {retries} retries')
+        if status >= 400:
+            raise WhisperQueryError(f'HTTP {status}: {raw[:500].decode("utf-8", "replace")}')
+
+        try:
+            parsed = json.loads(raw)
+        except ValueError as exc:
+            raise WhisperQueryError('non-JSON response body') from exc
+        if parsed.get('success') is False:
+            raise WhisperQueryError(str(parsed.get('error', 'unknown query error'))[:500])
+        rows = parsed.get('rows')
+        if not isinstance(rows, list):
+            raise WhisperQueryError('malformed response: missing rows')
+        return rows
+
+
+# --- IOC primitives -----------------------------------------------------------------------
+def _strip_port(value: str) -> str:
+    """'1.2.3.4:56' → '1.2.3.4'; '[::1]:56' → '::1'; anything else unchanged."""
+    if value.startswith('[') and ']' in value:
+        return value[1 : value.index(']')]
+    if value.count(':') == 1:
+        host, _, port = value.partition(':')
+        if '.' in host and port.isdigit():
+            return host
+    return value
+
+
+def parse_ip(value: str) -> 'ipaddress.IPv4Address | ipaddress.IPv6Address | None':
+    """The ipaddress object for a raw field value, or None when it isn't an IP.
+
+    Strips an ip:port suffix and unwraps IPv4-mapped IPv6 (::ffff:a.b.c.d).
+    """
+    try:
+        ip = ipaddress.ip_address(_strip_port(value))
+    except ValueError:
+        return None
+    if ip.version == 6 and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    return ip
+
+
+def classify_domain(value: str) -> 'str | None':
+    """Normalize + validate a domain-hinted value; None when it isn't a plausible domain."""
+    candidate = value.strip().rstrip('.').lower()
+    if _DOMAIN_RE.match(candidate):
+        return candidate
+    return None
+
+
+def extract_url_host(value: str) -> 'str | None':
+    """Host component of an ABSOLUTE url; None for path-only values (nginx/apache logs)."""
+    if '://' not in value:
+        return None
+    try:
+        return urlsplit(value).hostname or None
+    except ValueError:
+        return None
+
+
+# --- config resolution --------------------------------------------------------------------
+def resolve_api_url(options: dict, environ: dict) -> str:
+    """<options>.api_url → WHISPER_API_URL → default (mapping §2.3)."""
+    for candidate in (options.get('api_url'), environ.get('WHISPER_API_URL')):
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip().rstrip('/')
+    return DEFAULT_API_URL
+
+
+def resolve_api_key(argv_key: str, environ: dict, key_file: 'str | None' = None) -> 'str | None':
+    """WHISPER_API_KEY env → key file (640 root:wazuh) → argv_key; placeholder never counts.
+
+    `key_file` defaults to the module global at CALL time so tests can monkeypatch KEY_FILE.
+    """
+    if key_file is None:
+        key_file = KEY_FILE
+    env_key = environ.get('WHISPER_API_KEY', '').strip()
+    if env_key and env_key != API_KEY_PLACEHOLDER:
+        return env_key
+    try:
+        with open(key_file) as f:
+            file_key = f.read().strip()
+        if file_key and file_key != API_KEY_PLACEHOLDER:
+            return file_key
+    except OSError:
+        pass
+    argv_key = (argv_key or '').strip()
+    if argv_key and argv_key != API_KEY_PLACEHOLDER:
+        return argv_key
+    return None

--- a/integrations/whisper/whisper_client.py
+++ b/integrations/whisper/whisper_client.py
@@ -32,7 +32,7 @@ from urllib.parse import urlsplit
 _pwd = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 KEY_FILE = f'{_pwd}/etc/whisper.key'
 API_KEY_PLACEHOLDER = 'WHISPER_API_KEY_PLACEHOLDER'
-DEFAULT_API_URL = 'https://graph.whisper.security'
+DEFAULT_API_URL = 'https://graph.whisper.online'
 DEFAULT_TIMEOUT = 10
 DEFAULT_RETRIES = 3
 
@@ -41,7 +41,10 @@ CONNECTOR_VERSION = '1.0'
 # Must NOT start with 'Python-urllib' — the Whisper API WAF blocks that default UA.
 USER_AGENT = f'whisper-wazuh-connector/{CONNECTOR_VERSION}'
 BACKOFF_BASE = 0.5
-BACKOFF_CAP = 60.0
+# A few seconds, not 60: the connector runs inside a SYNCHRONOUS integratord callout (one alert
+# at a time, every other integration blocked behind it), so a long backoff sleep stalls the whole
+# manager. Retry-After values above the cap are clamped to it.
+BACKOFF_CAP = 5.0
 # Common CA-bundle locations, tried when the interpreter's compiled-in paths are empty.
 _CA_BUNDLE_CANDIDATES = (
     '/etc/ssl/certs/ca-certificates.crt',  # Debian/Ubuntu (Wazuh manager image)
@@ -71,6 +74,13 @@ class WhisperTransportError(WhisperError):
     """Network / 5xx / 429-after-retries — transient."""
 
     log_class = 'transport'
+
+
+class WhisperDeadlineError(WhisperTransportError):
+    """The caller's wall-clock budget ran out (before a request, during a backoff sleep, or — via
+    the connector's SIGALRM hard ceiling — inside a stalled socket operation). A transport-class
+    outage from the operator's point of view, but typed so callers can tell budget-exhaustion
+    apart from an API error whose text happens to mention a deadline."""
 
 
 class WhisperQueryError(WhisperError):
@@ -153,6 +163,34 @@ def _retry_after_seconds(headers: dict) -> 'float | None':
         return None
 
 
+def _remaining(deadline: 'float | None') -> 'float | None':
+    """Seconds left before the caller's wall-clock deadline (a time.monotonic() stamp), or None
+    when the caller set no deadline."""
+    return None if deadline is None else deadline - time.monotonic()
+
+
+def _effective_timeout(deadline: 'float | None', timeout: int) -> float:
+    """The per-request socket timeout, shrunk to whatever is left of the deadline. Raises once the
+    deadline has passed so a caller never starts a request it cannot finish in budget."""
+    remaining = _remaining(deadline)
+    if remaining is None:
+        return timeout
+    if remaining <= 0:
+        raise WhisperDeadlineError('deadline exceeded before request')
+    return max(0.1, min(timeout, remaining))
+
+
+def _sleep_within(delay: float, deadline: 'float | None', after: str) -> None:
+    """Back off for `delay` seconds (capped at BACKOFF_CAP) — but never past the deadline. If the
+    sleep would consume the remaining budget, fail now rather than sleep and then fail anyway.
+    `after` names what triggered the retry so the operator-facing error keeps its cause."""
+    delay = min(delay, BACKOFF_CAP)
+    remaining = _remaining(deadline)
+    if remaining is not None and delay >= remaining:
+        raise WhisperDeadlineError(f'deadline exceeded during backoff after {after}')
+    time.sleep(delay)
+
+
 def execute_query(
     api_url: str,
     api_key: 'str | None',
@@ -160,6 +198,7 @@ def execute_query(
     params: 'dict | None' = None,
     timeout: int = DEFAULT_TIMEOUT,
     retries: int = DEFAULT_RETRIES,
+    deadline: 'float | None' = None,
 ) -> 'list[dict]':
     """POST one Cypher query to /api/query; return `rows` (list of dicts keyed by column name).
 
@@ -168,6 +207,11 @@ def execute_query(
       429 / 5xx after retries    → WhisperTransportError (Retry-After honoured per attempt)
       network failure            → WhisperTransportError
       other 4xx / bad body       → WhisperQueryError
+
+    `deadline` (an optional time.monotonic() stamp) bounds the WHOLE call, retries included: each
+    request's socket timeout shrinks to what is left, and a retry that would sleep past the
+    deadline raises WhisperTransportError instead of sleeping. This is what keeps a synchronous
+    integratord callout to seconds when the API is slow or unreachable.
     """
     # An explicit User-Agent is REQUIRED: the Whisper API's WAF 403s urllib's default
     # `Python-urllib/x.y` UA (verified live 2026-07-11). Any non-default UA passes.
@@ -183,7 +227,7 @@ def execute_query(
     while True:
         started = time.monotonic()
         try:
-            status, raw, resp_headers = _http_post(url, body, headers, timeout)
+            status, raw, resp_headers = _http_post(url, body, headers, _effective_timeout(deadline, timeout))
         except (urllib.error.URLError, OSError, http.client.HTTPException) as exc:
             # http.client.HTTPException (BadStatusLine/IncompleteRead) is NOT an OSError —
             # catch it explicitly so a garbled response stays inside the retry budget and
@@ -191,7 +235,7 @@ def execute_query(
             log_api(api_url, int((time.monotonic() - started) * 1000))
             if attempt < retries:
                 attempt += 1
-                time.sleep(min(BACKOFF_BASE * (2 ** (attempt - 1)), BACKOFF_CAP))
+                _sleep_within(BACKOFF_BASE * (2 ** (attempt - 1)), deadline, f'network error ({exc})')
                 continue
             raise WhisperTransportError(f'network error after {retries} retries: {exc}') from exc
         log_api(api_url, int((time.monotonic() - started) * 1000))
@@ -204,7 +248,7 @@ def execute_query(
                 delay = _retry_after_seconds(resp_headers)
                 if delay is None:
                     delay = BACKOFF_BASE * (2 ** (attempt - 1))
-                time.sleep(min(delay, BACKOFF_CAP))
+                _sleep_within(delay, deadline, f'HTTP {status}')
                 continue
             raise WhisperTransportError(f'HTTP {status} after {retries} retries')
         if status >= 400:

--- a/integrations/whisper/whisper_rules.xml
+++ b/integrations/whisper/whisper_rules.xml
@@ -1,0 +1,80 @@
+<!--
+  Whisper enrichment rules — render the custom-whisper integration's data.whisper.*
+  events as analyst-visible alerts (verdict -> alert level). Mapping spec §6.
+
+  Install to /var/ossec/etc/rules/whisper_rules.xml (root:wazuh 660); restart the manager.
+
+  Field names carry NO `data.` prefix in rules XML (the JSON decoder flattens data.whisper.*
+  to whisper.*); query them as data.whisper.* only in OpenSearch/the dashboard. Verdict/level
+  matches are pcre2-anchored so a value can never substring-collide (osmatch default).
+
+  Rule ids 100200-100299 (custom range, above the built-in ceiling of 99999). The
+  `whisper_enrichment` group is the loop guard: it MUST NOT appear in the <integration>
+  trigger filter, so an enrichment alert can never re-invoke the integration (mapping §8).
+  no_full_log keeps the (up to 60 KB) injected JSON envelope out of each alert's full_log —
+  the data.whisper.* fields are decoded and indexed on their own; matches the stock
+  virustotal/maltiverse convention for re-decoded integration events.
+-->
+<group name="whisper,whisper_enrichment,">
+
+  <!-- Base classifier: level 0 = decode + tag only, no alert of its own -->
+  <rule id="100200" level="0">
+    <decoded_as>json</decoded_as>
+    <field name="integration" type="pcre2">^custom-whisper$</field>
+    <description>Whisper enrichment event</description>
+  </rule>
+
+  <rule id="100201" level="12">
+    <if_sid>100200</if_sid>
+    <field name="whisper.verdict" type="pcre2">^known_bad$</field>
+    <description>Whisper: $(whisper.ioc) is KNOWN BAD ($(whisper.level))</description>
+    <options>no_full_log</options>
+    <group>whisper_known_bad,</group>
+  </rule>
+
+  <!-- Escalate a known_bad to level 14 when the graph level is CRITICAL -->
+  <rule id="100205" level="14">
+    <if_sid>100201</if_sid>
+    <field name="whisper.level" type="pcre2">^CRITICAL$</field>
+    <description>Whisper: $(whisper.ioc) is KNOWN BAD (CRITICAL)</description>
+    <options>no_full_log</options>
+    <group>whisper_known_bad,</group>
+  </rule>
+
+  <rule id="100202" level="7">
+    <if_sid>100200</if_sid>
+    <field name="whisper.verdict" type="pcre2">^suspicious$</field>
+    <description>Whisper: $(whisper.ioc) is SUSPICIOUS ($(whisper.level))</description>
+    <options>no_full_log</options>
+    <group>whisper_suspicious,</group>
+  </rule>
+
+  <rule id="100203" level="3">
+    <if_sid>100200</if_sid>
+    <field name="whisper.verdict" type="pcre2">^known_good$</field>
+    <description>Whisper: $(whisper.ioc) is known good</description>
+    <options>no_full_log</options>
+    <group>whisper_known_good,</group>
+  </rule>
+
+  <rule id="100204" level="3">
+    <if_sid>100200</if_sid>
+    <field name="whisper.verdict" type="pcre2">^unknown$</field>
+    <description>Whisper: no graph data for $(whisper.ioc)</description>
+    <options>no_full_log</options>
+    <group>whisper_unknown,</group>
+  </rule>
+
+  <!-- Opt-in TLS-fingerprint enrichment (#32). A Cobalt Strike default JARM is a strong C2
+       indicator the threat feeds routinely miss (~97% of emitters read clean), so it escalates
+       INDEPENDENT of verdict — the verdict for such an IP is usually 'unknown'. Fires only when
+       the tls_fingerprint enrichment is enabled AND the IP is in the JARM catalog. -->
+  <rule id="100206" level="12">
+    <if_sid>100200</if_sid>
+    <field name="whisper.tls.family" type="pcre2">^cobalt-strike-default$</field>
+    <description>Whisper: $(whisper.ioc) emits a Cobalt Strike default JARM fingerprint (possible C2)</description>
+    <options>no_full_log</options>
+    <group>whisper_c2,</group>
+  </rule>
+
+</group>

--- a/integrations/whisper/whisper_rules.xml
+++ b/integrations/whisper/whisper_rules.xml
@@ -8,7 +8,8 @@
   to whisper.*); query them as data.whisper.* only in OpenSearch/the dashboard. Verdict/level
   matches are pcre2-anchored so a value can never substring-collide (osmatch default).
 
-  Rule ids 100200-100299 (custom range, above the built-in ceiling of 99999). The
+  Rule ids 100500-100509 (custom range, above the built-in ceiling of 99999; the agent-activity
+  log source uses the adjacent 100510-100549 band). The
   `whisper_enrichment` group is the loop guard: it MUST NOT appear in the <integration>
   trigger filter, so an enrichment alert can never re-invoke the integration (mapping §8).
   no_full_log keeps the (up to 60 KB) injected JSON envelope out of each alert's full_log —
@@ -18,14 +19,14 @@
 <group name="whisper,whisper_enrichment,">
 
   <!-- Base classifier: level 0 = decode + tag only, no alert of its own -->
-  <rule id="100200" level="0">
+  <rule id="100500" level="0">
     <decoded_as>json</decoded_as>
     <field name="integration" type="pcre2">^custom-whisper$</field>
     <description>Whisper enrichment event</description>
   </rule>
 
-  <rule id="100201" level="12">
-    <if_sid>100200</if_sid>
+  <rule id="100501" level="12">
+    <if_sid>100500</if_sid>
     <field name="whisper.verdict" type="pcre2">^known_bad$</field>
     <description>Whisper: $(whisper.ioc) is KNOWN BAD ($(whisper.level))</description>
     <options>no_full_log</options>
@@ -33,32 +34,32 @@
   </rule>
 
   <!-- Escalate a known_bad to level 14 when the graph level is CRITICAL -->
-  <rule id="100205" level="14">
-    <if_sid>100201</if_sid>
+  <rule id="100505" level="14">
+    <if_sid>100501</if_sid>
     <field name="whisper.level" type="pcre2">^CRITICAL$</field>
     <description>Whisper: $(whisper.ioc) is KNOWN BAD (CRITICAL)</description>
     <options>no_full_log</options>
     <group>whisper_known_bad,</group>
   </rule>
 
-  <rule id="100202" level="7">
-    <if_sid>100200</if_sid>
+  <rule id="100502" level="7">
+    <if_sid>100500</if_sid>
     <field name="whisper.verdict" type="pcre2">^suspicious$</field>
     <description>Whisper: $(whisper.ioc) is SUSPICIOUS ($(whisper.level))</description>
     <options>no_full_log</options>
     <group>whisper_suspicious,</group>
   </rule>
 
-  <rule id="100203" level="3">
-    <if_sid>100200</if_sid>
+  <rule id="100503" level="3">
+    <if_sid>100500</if_sid>
     <field name="whisper.verdict" type="pcre2">^known_good$</field>
     <description>Whisper: $(whisper.ioc) is known good</description>
     <options>no_full_log</options>
     <group>whisper_known_good,</group>
   </rule>
 
-  <rule id="100204" level="3">
-    <if_sid>100200</if_sid>
+  <rule id="100504" level="3">
+    <if_sid>100500</if_sid>
     <field name="whisper.verdict" type="pcre2">^unknown$</field>
     <description>Whisper: no graph data for $(whisper.ioc)</description>
     <options>no_full_log</options>
@@ -69,8 +70,8 @@
        indicator the threat feeds routinely miss (~97% of emitters read clean), so it escalates
        INDEPENDENT of verdict — the verdict for such an IP is usually 'unknown'. Fires only when
        the tls_fingerprint enrichment is enabled AND the IP is in the JARM catalog. -->
-  <rule id="100206" level="12">
-    <if_sid>100200</if_sid>
+  <rule id="100506" level="12">
+    <if_sid>100500</if_sid>
     <field name="whisper.tls.family" type="pcre2">^cobalt-strike-default$</field>
     <description>Whisper: $(whisper.ioc) emits a Cobalt Strike default JARM fingerprint (possible C2)</description>
     <options>no_full_log</options>


### PR DESCRIPTION
## What

Adds a new integration: **Whisper threat-intelligence enrichment**.

It enriches Wazuh alerts with relationship context from the [Whisper](https://www.whisper.security) infrastructure graph (ASNs, prefixes, DNS, WHOIS, threat feeds, Tor relays, TLS fingerprints). When an alert carries a public IP or domain, a Pattern-A `integratord` custom script (`custom-whisper`) queries the graph and writes an **evidence-graded verdict** back into Wazuh as a new alert under `data.whisper.*` (verdict → alert level via the bundled rules).

## Details

- **`integrations/whisper/`** — `custom-whisper` (shell wrapper) + `custom-whisper.py` (connector) + `whisper_client.py` (shared HTTP/TLS client) + `whisper_rules.xml` (verdict→level) + `whisper-template.json` (indexer field types).
- **Stdlib-only Python** on the manager's bundled interpreter — nothing to `pip install`.
- **Keyless** — the graph enrichment needs no API key.
- The README follows the repo format: Introduction, verdict→level table, install & configuration, the `ossec.conf` block, custom rules, manual tests (`wazuh-logtest` + a live connector run), and Sources/provenance.

## Tested

Wazuh **4.14.5**.

## Provenance

- Adapted by / maintainer: **Whisper Security** (`security@whisper.security`)
- Upstream project (installers, full docs, and the keyed agent-activity tier): <https://github.com/whisper-sec/whisper-wazuh>

🤖 Generated with [Claude Code](https://claude.com/claude-code)